### PR TITLE
LPS-75593 After session timeout Social Ratings notifies user to sign in

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
@@ -496,59 +496,75 @@ AUI.add(
 						var instance = this;
 
 						var cssClasses = instance.ratings.get('cssClasses');
+						
 						var elements = instance.ratings.get('elements');
-
-						var cssClassesOn = cssClasses.on;
-
-						var ratingThumbDown = elements.item(1);
-
-						var ratingThumbDownCssClassOn = false;
-
-						if (ratingThumbDown) {
-							ratingThumbDownCssClassOn = ratingThumbDown.hasClass(cssClassesOn);
-						}
 
 						var ratingThumbUp = elements.item(0);
 
-						var ratingThumbUpCssClassOn = false;
+						var ratingThumbDown = elements.item(1);
 
-						if (ratingThumbUp) {
-							ratingThumbUpCssClassOn = ratingThumbUp.hasClass(cssClassesOn);
+						if (isNaN(thumbScore.negativeVotes)) {
+							var sessionTimeout = Liferay.Language.get('you-need-to-be-signed-in-to-rate');
+
+							ratingThumbUp.attr('title', sessionTimeout);
+							ratingThumbUp.addClass(cssClasses.off);
+							ratingThumbUp.removeClass(cssClasses.on);
+
+							ratingThumbDown.attr('title', sessionTimeout);
+							ratingThumbDown.addClass(cssClasses.off);
+							ratingThumbDown.removeClass(cssClasses.on);
+
+							instance.ratings.set('disabled', true);
 						}
+						else {
+							var cssClassesOn = cssClasses.on;
 
-						var thumbDownMessage = '';
-						var thumbUpMessage = '';
+							var ratingThumbDownCssClassOn = false;
 
-						if (ratingThumbDown) {
-							if (ratingThumbDownCssClassOn) {
-								thumbDownMessage = Liferay.Language.get('you-have-rated-this-as-bad');
+							if (ratingThumbDown) {
+								ratingThumbDownCssClassOn = ratingThumbDown.hasClass(cssClassesOn);
 							}
-							else {
-								thumbDownMessage = Liferay.Language.get('rate-this-as-bad');
+
+							var ratingThumbUpCssClassOn = false;
+
+							if (ratingThumbUp) {
+								ratingThumbUpCssClassOn = ratingThumbUp.hasClass(cssClassesOn);
 							}
 
-							ratingThumbDown.attr('title', thumbDownMessage);
+							var thumbDownMessage = '';
+							var thumbUpMessage = '';
 
-							ratingThumbDown.html(thumbScore.negativeVotes);
-						}
+							if (ratingThumbDown) {
+								if (ratingThumbDownCssClassOn) {
+									thumbDownMessage = Liferay.Language.get('you-have-rated-this-as-bad');
+								}
+								else {
+									thumbDownMessage = Liferay.Language.get('rate-this-as-bad');
+								}
 
-						if (ratingThumbDown && ratingThumbUpCssClassOn) {
-							thumbUpMessage = Liferay.Language.get('you-have-rated-this-as-good');
-						}
-						else if (ratingThumbDown && !ratingThumbUpCssClassOn) {
-							thumbUpMessage = Liferay.Language.get('rate-this-as-good');
-						}
-						else if (!ratingThumbDown && ratingThumbUpCssClassOn) {
-							thumbUpMessage = Liferay.Language.get('unlike-this');
-						}
-						else if (!ratingThumbDown && !ratingThumbUpCssClassOn) {
-							thumbUpMessage = Liferay.Language.get('like-this');
-						}
+								ratingThumbDown.attr('title', thumbDownMessage);
 
-						if (ratingThumbUp) {
-							ratingThumbUp.attr('title', thumbUpMessage);
+								ratingThumbDown.html(thumbScore.negativeVotes);
+							}
 
-							ratingThumbUp.html(thumbScore.positiveVotes);
+							if (ratingThumbDown && ratingThumbUpCssClassOn) {
+								thumbUpMessage = Liferay.Language.get('you-have-rated-this-as-good');
+							}
+							else if (ratingThumbDown && !ratingThumbUpCssClassOn) {
+								thumbUpMessage = Liferay.Language.get('rate-this-as-good');
+							}
+							else if (!ratingThumbDown && ratingThumbUpCssClassOn) {
+								thumbUpMessage = Liferay.Language.get('unlike-this');
+							}
+							else if (!ratingThumbDown && !ratingThumbUpCssClassOn) {
+								thumbUpMessage = Liferay.Language.get('like-this');
+							}
+
+							if (ratingThumbUp) {
+								ratingThumbUp.attr('title', thumbUpMessage);
+
+								ratingThumbUp.html(thumbScore.positiveVotes);
+							}
 						}
 					}
 				}

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -5742,6 +5742,7 @@ you-must-be-authenticated-to-use-this-portlet=You must be authenticated to use t
 you-must-first-add-a-vocabulary=You must first add a vocabulary.
 you-must-specify-a-site-id-and-artifact-id-before-you-can-add-a-product-version=You must specify a site ID and artifact ID before you can add a product version.
 you-need-to-approve-x-as-your-friend=You need to approve {0} as your friend.
+you-need-to-be-signed-in-to-rate=You need to be signed in to rate.
 you-save=You Save
 you-were-redirected-to-x=You were redirected to <em>{0}</em>.
 you-will-be-sent-an-email-notification-when-each-of-the-recipients-of-this-email-have-opened-to-read-this-email=You will be sent an email notification when each of the recipients of this email have opened to read this email.


### PR DESCRIPTION
When the session times out and the user tries to rate a thread, the output will print "NaN". This is because the user does not have permission to leave a rating without being signed in.

The fix for this was checking when we receive the "NaN", which indicates the user is signed out, and graying out the rating icons. The user will no longer be able to click on the icons, but can see a tool tip stating to log in.  