### PR TITLE
[TECHNICAL-SUPPORT] LPS-87055 duplicate page template vague error 

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddLayoutPrototypeMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddLayoutPrototypeMVCActionCommand.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.admin.web.internal.portlet.action;
 
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateEntryException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateEntryNameException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
@@ -140,8 +141,16 @@ public class AddLayoutPrototypeMVCActionCommand extends BaseMVCActionCommand {
 
 			String errorMessage = "an-unexpected-error-occurred";
 
-			if (t.getCause() instanceof LayoutPageTemplateEntryNameException) {
+			Throwable cause = t.getCause();
+
+			if (cause instanceof LayoutPageTemplateEntryNameException) {
 				errorMessage = "please-enter-a-valid-name";
+			}
+			else if (cause instanceof
+						DuplicateLayoutPageTemplateEntryException) {
+
+				errorMessage =
+					"a-page-template-entry-with-that-name-already-exists";
 			}
 
 			jsonObject.put(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutPrototypeMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutPrototypeMVCActionCommand.java
@@ -15,7 +15,8 @@
 package com.liferay.layout.admin.web.internal.portlet.action;
 
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateEntryException;
+import com.liferay.layout.page.template.exception.LayoutPageTemplateEntryNameException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -84,18 +85,29 @@ public class UpdateLayoutPrototypeMVCActionCommand
 
 			jsonObject.put("redirectURL", redirect);
 		}
-		catch (PortalException pe) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(pe, pe);
-			}
+		catch (Throwable t) {
+			_log.error(t, t);
 
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
+			String errorMessage = "an-unexpected-error-occurred";
+
+			Throwable cause = t.getCause();
+
+			if (cause instanceof LayoutPageTemplateEntryNameException) {
+				errorMessage = "please-enter-a-valid-name";
+			}
+			else if (cause instanceof
+						DuplicateLayoutPageTemplateEntryException) {
+
+				errorMessage =
+					"a-page-template-entry-with-that-name-already-exists";
+			}
+
 			jsonObject.put(
 				"error",
-				LanguageUtil.get(
-					themeDisplay.getRequest(), "an-unexpected-error-occurred"));
+				LanguageUtil.get(themeDisplay.getRequest(), errorMessage));
 		}
 
 		JSONPortletResponseUtil.writeJSON(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalService.java
@@ -390,6 +390,10 @@ public interface LayoutPageTemplateEntryLocalService extends BaseLocalService,
 		long layoutPageTemplateEntryId, long classNameId, long classTypeId)
 		throws PortalException;
 
+	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(long userId,
+		long layoutPageTemplateEntryId, String name, int status)
+		throws PortalException;
+
 	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
 		long layoutPageTemplateEntryId, String name) throws PortalException;
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceUtil.java
@@ -501,6 +501,14 @@ public class LayoutPageTemplateEntryLocalServiceUtil {
 	}
 
 	public static com.liferay.layout.page.template.model.LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
+		long userId, long layoutPageTemplateEntryId, String name, int status)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .updateLayoutPageTemplateEntry(userId,
+			layoutPageTemplateEntryId, name, status);
+	}
+
+	public static com.liferay.layout.page.template.model.LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
 		long layoutPageTemplateEntryId, String name)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService()

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceWrapper.java
@@ -517,6 +517,14 @@ public class LayoutPageTemplateEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.layout.page.template.model.LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
+		long userId, long layoutPageTemplateEntryId, String name, int status)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(userId,
+			layoutPageTemplateEntryId, name, status);
+	}
+
+	@Override
+	public com.liferay.layout.page.template.model.LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
 		long layoutPageTemplateEntryId, String name)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(layoutPageTemplateEntryId,

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutPrototypeModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutPrototypeModelListener.java
@@ -102,36 +102,49 @@ public class LayoutPrototypeModelListener
 	public void onAfterUpdate(LayoutPrototype layoutPrototype)
 		throws ModelListenerException {
 
-		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.
-				fetchFirstLayoutPageTemplateEntry(
-					layoutPrototype.getLayoutPrototypeId());
+		try {
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_layoutPageTemplateEntryLocalService.
+					fetchFirstLayoutPageTemplateEntry(
+						layoutPrototype.getLayoutPrototypeId());
 
-		if (layoutPageTemplateEntry == null) {
-			return;
+			if (layoutPageTemplateEntry == null) {
+				return;
+			}
+
+			String nameXML = layoutPrototype.getName();
+
+			Map<Locale, String> nameMap = LocalizationUtil.getLocalizationMap(
+				nameXML);
+
+			Locale defaultLocale = LocaleUtil.fromLanguageId(
+				LocalizationUtil.getDefaultLanguageId(nameXML));
+
+			String name = nameMap.get(defaultLocale);
+
+			int status;
+
+			if (layoutPrototype.isActive()) {
+				status = WorkflowConstants.STATUS_APPROVED;
+			}
+			else {
+				status = WorkflowConstants.STATUS_INACTIVE;
+			}
+
+			long layoutPageTemplateEntryId =
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId();
+			long userId = layoutPageTemplateEntry.getUserId();
+
+			_layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(
+				userId, layoutPageTemplateEntryId, name, status);
 		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
 
-		String nameXML = layoutPrototype.getName();
-
-		Map<Locale, String> nameMap = LocalizationUtil.getLocalizationMap(
-			nameXML);
-
-		Locale defaultLocale = LocaleUtil.fromLanguageId(
-			LocalizationUtil.getDefaultLanguageId(nameXML));
-
-		layoutPageTemplateEntry.setName(nameMap.get(defaultLocale));
-
-		if (layoutPrototype.isActive()) {
-			layoutPageTemplateEntry.setStatus(
-				WorkflowConstants.STATUS_APPROVED);
+			throw new ModelListenerException(pe);
 		}
-		else {
-			layoutPageTemplateEntry.setStatus(
-				WorkflowConstants.STATUS_INACTIVE);
-		}
-
-		_layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(
-			layoutPageTemplateEntry);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -73,9 +74,20 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			status = WorkflowConstants.STATUS_INACTIVE;
 		}
 
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		long groupId;
+
+		if (serviceContext != null) {
+			groupId = serviceContext.getScopeGroupId();
+		}
+		else {
+			groupId = company.getGroupId();
+		}
+
 		return addLayoutPageTemplateEntry(
-			layoutPrototype.getUserId(), company.getGroupId(), 0,
-			nameMap.get(defaultLocale),
+			layoutPrototype.getUserId(), groupId, 0, nameMap.get(defaultLocale),
 			LayoutPageTemplateEntryTypeConstants.TYPE_WIDGET_PAGE,
 			layoutPrototype.getLayoutPrototypeId(), status,
 			new ServiceContext());

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -131,10 +131,12 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 		layoutPageTemplateEntry.setPreviewFileEntryId(previewFileEntryId);
 		layoutPageTemplateEntry.setDefaultTemplate(defaultTemplate);
 		layoutPageTemplateEntry.setLayoutPrototypeId(layoutPrototypeId);
-		layoutPageTemplateEntry.setStatus(status);
-		layoutPageTemplateEntry.setStatusByUserId(userId);
-		layoutPageTemplateEntry.setStatusByUserName(user.getFullName());
-		layoutPageTemplateEntry.setStatusDate(new Date());
+
+		String userName = user.getFullName();
+		Date statusDate = new Date();
+
+		setStatusFields(
+			layoutPageTemplateEntry, userId, userName, status, statusDate);
 
 		layoutPageTemplateEntryPersistence.update(layoutPageTemplateEntry);
 
@@ -463,17 +465,20 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			long userId, long layoutPageTemplateEntryId, int status)
 		throws PortalException {
 
-		User user = userLocalService.getUser(userId);
-
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			layoutPageTemplateEntryPersistence.findByPrimaryKey(
 				layoutPageTemplateEntryId);
 
 		layoutPageTemplateEntry.setModifiedDate(new Date());
-		layoutPageTemplateEntry.setStatus(status);
-		layoutPageTemplateEntry.setStatusByUserId(userId);
-		layoutPageTemplateEntry.setStatusByUserName(user.getScreenName());
-		layoutPageTemplateEntry.setStatusDate(new Date());
+
+		User user = userLocalService.getUser(userId);
+
+		String userName = user.getScreenName();
+
+		Date statusDate = new Date();
+
+		setStatusFields(
+			layoutPageTemplateEntry, userId, userName, status, statusDate);
 
 		return layoutPageTemplateEntryLocalService.
 			updateLayoutPageTemplateEntry(layoutPageTemplateEntry);
@@ -503,6 +508,36 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			layoutPageTemplateEntryId, classTypeId);
 
 		return layoutPageTemplateEntry;
+	}
+
+	@Override
+	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
+			long userId, long layoutPageTemplateEntryId, String name,
+			int status)
+		throws PortalException {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			layoutPageTemplateEntryPersistence.findByPrimaryKey(
+				layoutPageTemplateEntryId);
+
+		if (!Objects.equals(layoutPageTemplateEntry.getName(), name)) {
+			validate(layoutPageTemplateEntry.getGroupId(), name);
+		}
+
+		layoutPageTemplateEntry.setModifiedDate(new Date());
+		layoutPageTemplateEntry.setName(name);
+
+		User user = userLocalService.getUser(userId);
+
+		String userName = user.getScreenName();
+
+		Date statusDate = new Date();
+
+		setStatusFields(
+			layoutPageTemplateEntry, userId, userName, status, statusDate);
+
+		return layoutPageTemplateEntryLocalService.
+			updateLayoutPageTemplateEntry(layoutPageTemplateEntry);
 	}
 
 	@Override
@@ -559,6 +594,16 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			serviceContext);
 
 		return layoutPageTemplateEntry;
+	}
+
+	protected void setStatusFields(
+		LayoutPageTemplateEntry layoutPageTemplateEntry, long userId,
+		String userName, int status, Date statusDate) {
+
+		layoutPageTemplateEntry.setStatus(status);
+		layoutPageTemplateEntry.setStatusByUserId(userId);
+		layoutPageTemplateEntry.setStatusByUserName(userName);
+		layoutPageTemplateEntry.setStatusDate(statusDate);
 	}
 
 	protected void validate(long groupId, String name) throws PortalException {


### PR DESCRIPTION
Issue:
Adding a Widget Page Template with a duplicate name as an existing Content/Widget Page Template displays vague error.

Cause:

The validation in the service layer does not catch that the page template is a duplicate template because it searching for duplicates under the wrong site.
The error handling does not use the right error message.
Fix:

Get the scope group ID from the service context from the local thread via ServiceContextThreadLocal.
Add error handling for the DuplicateLayoutPageTemplateEntryException so the right error message gets displayed.
Another related issue found during testing:
Renaming a Widget Page Template with a duplicate name as an existing Content/Widget Page Template causes the save dialog to hang.

Cause:

There is no validation in the service layer. The base class (LayoutPageTemplateEntryLocalServiceBaseImpl) method is getting called so there is no validate method called in the subclass (LayoutPageTemplateEntryLocalServiceImpl).
The error handling does not use the right error message.