### PR TITLE
[TS] User notification about lockout is shown in the server's time zone which can be confusing for a user in a different time zone

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -57,9 +57,11 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
 
+import java.text.DateFormat;
 import java.text.Format;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
 
 import java.util.Collections;
 import java.util.Date;
@@ -1835,6 +1837,12 @@ public class LanguageImpl implements Language, Serializable {
 				}
 
 				sb.append(dateFormat.format(argument));
+
+				DateFormat getTimeZoneShort = new SimpleDateFormat("z", locale);
+
+				String timeZoneShort = " " + getTimeZoneShort.format(argument);
+
+				sb.append(timeZoneShort);
 			}
 			else {
 				sb.append(argument);


### PR DESCRIPTION
Hi Eric,

Please review my fix, I have created it based on your earlier suggestions.
I have checked the [FastDateFormatConstants](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/util/FastDateFormatConstants.java) possibilities but none of them provided the time format that I needed, that is why I have used the existing StringBuilder in LanguageImpl to add the timezone information.

If you approve this change, please forward it to the next approver,
Thank you,
Peter
