### PR TITLE
[TS] User notification about lockout is shown in the server's time zone which can be confusing for a user in a different time zone

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CookieKeys;
+import com.liferay.portal.kernel.util.FastDateFormatConstants;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -1831,7 +1832,9 @@ public class LanguageImpl implements Language, Serializable {
 			}
 			else if (argument instanceof Date) {
 				if (dateFormat == null) {
-					dateFormat = FastDateFormatFactoryUtil.getDateTime(locale);
+					dateFormat = FastDateFormatFactoryUtil.getDateTime(
+						FastDateFormatConstants.SHORT,
+						FastDateFormatConstants.LONG, locale, null);
 				}
 
 				sb.append(dateFormat.format(argument));


### PR DESCRIPTION
Dear @ericyanLr,

I have created a new fix based on your latest suggestions, in a new repository.
Local testing showed correct results.
Link to the LPS ticket:
[LPS-86512](https://issues.liferay.com/browse/LPS-86512)

If you approve this change, please forward it to the next approver,
Thank you,
Peter