### PR TITLE
LPS-87074 Avoid NPE when job is unscheduled on master node

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -886,6 +886,18 @@ public class ClusterSchedulerEngine
 					SchedulerResponse schedulerResponse =
 						memoryClusteredJob.getKey();
 
+					if ((schedulerResponse == null) ||
+						(schedulerResponse.getTrigger() == null)) {
+
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Memory clustered job is not yet deployed on " +
+									"master");
+						}
+
+						continue;
+					}
+
 					Trigger oldTrigger = schedulerResponse.getTrigger();
 
 					Date startDate = oldTrigger.getFireDateAfter(new Date());


### PR DESCRIPTION
[LPS-87074](https://issues.liferay.com/browse/LPS-87074)

Hi Eric,

The issue is that slave node throws NullPointerException if there is an unscheduled job on master. This is very similar to [LPS-77562](https://issues.liferay.com/browse/LPS-77562) and I used the same approach to fix it.

Please review my change and let me know if there is anything I can help you with.

Thank you,
Istvan