### PR TITLE
[TS] LPS-92726 Upgrade jgroups.jar library from 3.6.4.Final to 3.6.16

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -1744,7 +1744,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.cluster.multiple.jar!jgroups.jar</file-name>
-				<version>3.6.4.Final</version>
+				<version>3.6.16.Final</version>
 				<project-name>JGroups</project-name>
 				<project-url>http://www.jgroups.org</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -788,7 +788,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.cluster.multiple.jar!jgroups.jar</td><td nowrap>3.6.4.Final</td><td nowrap><a href="http://www.jgroups.org">JGroups</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0</a>
+<td nowrap>com.liferay.portal.cluster.multiple.jar!jgroups.jar</td><td nowrap>3.6.16.Final</td><td nowrap><a href="http://www.jgroups.org">JGroups</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/portal/portal-cluster-multiple/build.gradle
+++ b/modules/apps/portal/portal-cluster-multiple/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileInclude group: "org.jgroups", name: "jgroups", version: "3.6.4.Final"
+	compileInclude group: "org.jgroups", name: "jgroups", version: "3.6.16.Final"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"


### PR DESCRIPTION
Hi Eric,

Please review my code change, it is about upgrading jgroups:
Link to LPS ticket:
[LPS-92726](https://issues.liferay.com/browse/LPS-92726)

My Team Leader requested the jar file upgrade based on the information we have currently in the mentioned LPS ticket and it's related LPP ticket.
Please let me know if there are other considerations (like in the past, in LPS-54709 the jgroups channel properties had to be adjusted in portal.properties)

Thank you,
Peter