### PR TITLE
[TS] LPS-92894 List of operation systems does not load in Liferay Mobile Device Detection Portlet Lite

### DIFF
--- a/modules/apps/portal-mobile-device-detection-fiftyonedegrees/portal-mobile-device-detection-fiftyonedegrees/src/main/java/com/liferay/portal/mobile/device/detection/fiftyonedegrees/internal/portal/profile/ModulePortalProfile.java
+++ b/modules/apps/portal-mobile-device-detection-fiftyonedegrees/portal-mobile-device-detection-fiftyonedegrees/src/main/java/com/liferay/portal/mobile/device/detection/fiftyonedegrees/internal/portal/profile/ModulePortalProfile.java
@@ -18,7 +18,10 @@ import com.liferay.portal.mobile.device.detection.fiftyonedegrees.internal.data.
 import com.liferay.portal.profile.BaseDSModulePortalProfile;
 import com.liferay.portal.profile.PortalProfile;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -32,9 +35,13 @@ public class ModulePortalProfile extends BaseDSModulePortalProfile {
 
 	@Activate
 	public void activate(ComponentContext componentContext) {
+		Set<String> supportedPortalProfileNames = new HashSet<>(
+			Arrays.asList(
+				PortalProfile.PORTAL_PROFILE_NAME_CE,
+				PortalProfile.PORTAL_PROFILE_NAME_DXP));
+
 		init(
-			componentContext,
-			Collections.singleton(PortalProfile.PORTAL_PROFILE_NAME_CE),
+			componentContext, supportedPortalProfileNames,
 			FiftyOneDegreesDataFileProvider.class.getName());
 	}
 


### PR DESCRIPTION
Dear Eric,

I have created a fix for LPS-92894 based on your investigation results on:
https://issues.liferay.com/browse/PTR-731

Could you please review my fix?

Link to the LPS ticket:
[LPS-92894](https://issues.liferay.com/browse/LPS-92894)

I have built my code with this change and the list of Op. Systems appeared correctly (even if I built an lpkg and tested it against an 7.1 EE FP9 portal).

If you approve this change, please forward it to the next approver,
Thank you, Peter