### PR TITLE
LPS-92701 Impossible to add image with page-scope, when virtual host is used

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/RequestBackedPortletURLFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/RequestBackedPortletURLFactoryUtil.java
@@ -221,7 +221,7 @@ public class RequestBackedPortletURLFactoryUtil {
 				controlPanelLayout = themeDisplay.getControlPanelLayout();
 
 				if (group == null) {
-					group = themeDisplay.getScopeGroup();
+					group = themeDisplay.getSiteGroup();
 				}
 			}
 


### PR DESCRIPTION
Hey @ericyanLr 

Could you please review this pull request?

As you suggested in the PTR, changing the `group` from `themeDisplay.getScopeGroup()` to `themeDisplay.getSiteGroup()` solves the issue.

Thank you and best regards,
István