### PR TITLE
LPS-92701 Impossible to add image in message with page-scope, when virtual host is used

### DIFF
--- a/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
+++ b/modules/apps/message-boards/message-boards-editor-configuration/src/main/java/com/liferay/message/boards/editor/configuration/internal/MBAttachmentHTMLEditorConfigContributor.java
@@ -25,6 +25,7 @@ import com.liferay.message.boards.constants.MBPortletKeys;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -65,9 +66,16 @@ public class MBAttachmentHTMLEditorConfigContributor
 		String name = GetterUtil.getString(
 			inputEditorTaglibAttributes.get("liferay-ui:input-editor:name"));
 
+		Group group = themeDisplay.getRefererGroup();
+
+		if (group == null) {
+			group = themeDisplay.getSiteGroup();
+		}
+
 		PortletURL itemSelectorURL = _itemSelector.getItemSelectorURL(
-			requestBackedPortletURLFactory, namespace + name + "selectItem",
-			getImageItemSelectorCriterion(), getURLItemSelectorCriterion());
+			requestBackedPortletURLFactory, group, 0,
+			namespace + name + "selectItem", getImageItemSelectorCriterion(),
+			getURLItemSelectorCriterion());
 
 		jsonObject.put(
 			"filebrowserImageBrowseLinkUrl", itemSelectorURL.toString());


### PR DESCRIPTION
Hi @ericyanLr 

Following your observations in https://github.com/ericyanLr/liferay-portal/pull/114, I discovered that the issue can be solved with a more Message Board specific, less general solution, so that no core classes will be modified.

You suggested that the group may be determined in `DocumentsAndMediaURLEditorConfigContributor`, but, it turned out that doing so has no effect on the behavior. Additionally,  `DocumentsAndMediaURLEditorConfigContributor` is not the only `*EditorConfigContributor` called during the Item Selection process.
Changing `MBAttachmentHTMLEditorConfigContributor` did solve the issue however, apparently because it's the one responsible for configuring the editor for the MB Message content.

Please let me know if you have further questions/observations.

Best regards,
István