### PR TITLE
LPS-87074 Unscheduling a job from the master node causes NPE on slave rejoin

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -886,6 +886,16 @@ public class ClusterSchedulerEngine
 					SchedulerResponse schedulerResponse =
 						memoryClusteredJob.getKey();
 
+					if (schedulerResponse.getTrigger() == null) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Unable to scedule memory clustered job " +
+									schedulerResponse);
+						}
+
+						continue;
+					}
+
 					Trigger oldTrigger = schedulerResponse.getTrigger();
 
 					Date startDate = oldTrigger.getFireDateAfter(new Date());


### PR DESCRIPTION
[LPS-87074](https://issues.liferay.com/browse/LPS-87074)

Hi Eric,

This is the continuation of https://github.com/ericyanLr/liferay-portal/pull/107. Sorry for the long delay in resending.

Hopefully I managed to address your previous concerns, but let me know if I forgot to clarify something.

> Null Check
> Looking at the code and the exception described on the ticket, it looks like the NullPointerException is being caused by the trigger object being null.
> 
> But, I haven't actually investigated this issue, so I don't know for sure if we would ever expect the schedulerResponse object to be null. From my understanding, the current logic does not expect that object to be null.
> 
> If you think that there is a chance that the schedulerResponse would ever be null, after your investigation into this issue, then I think it would be reasonable to add that null check. I just want to make sure we're not adding unnecessary checks.

You are right. We are transferring only non-null schedulerResponse objects (check is in [QuartzSchedulerEngine.getScheduledJobs(Scheduler, String, StorageType)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java#L690-L714)), so null check on the Trigger is enough.

> Log Message
> In regards to the log message, do you know if a log message is necessary or would be helpful?
> Basically, can we think of any use-cases where the log message would be helpful?
> 
> From my understanding, the main goal of the logic is for a slave node to retrieve the scheduled jobs from the master node.
> 
> To me, a deciding factor would be the following question: Is it okay for the retrieved schedulerResponse to not have a trigger?
> 
> If that's okay and is an expected scenario, then I don't think a log message would be necessary.

In my opinion, it is useful to log that we don't schedule a memory clustered job that was originally scheduled on master. 

To schedule a job we need a trigger, which is created when the corresponding MessageListener gets activated and available via scheduler.getTrigger(triggerKey) as long as the job is not UNSCHEDULED. Once we unschedule the job, we are not able to retrieve/recreate the trigger. (scheduler.getTrigger(triggerKey) returns null for UNSCHEDULED jobs.)

The log message gives a chance to the deployer to decide if the job is important or not and proceed accordingly.

Please, let me know if any other question comes up.

Thank you in advance,
Istvan