### PR TITLE
LPS-92701 Impossible to add image in message with page-scope, when virtual host is used

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8556,7 +8556,7 @@ public class PortalImpl implements Portal {
 						themeDisplay.getSiteGroupId()) &&
 					 (group.getClassPK() != themeDisplay.getUserId()))) {
 
-					if (group.isControlPanel()) {
+					if (group.isControlPanel() || controlPanel) {
 						virtualHostname = themeDisplay.getServerName();
 
 						if (Validator.isNull(virtualHostname) ||

--- a/portal-impl/test/integration/com/liferay/portal/util/PortalImplLayoutRelativeURLTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/PortalImplLayoutRelativeURLTest.java
@@ -73,6 +73,11 @@ public class PortalImplLayoutRelativeURLTest extends BasePortalImplURLTestCase {
 			initThemeDisplay(company, group, publicLayout, LOCALHOST),
 			publicLayout, publicLayoutRelativeURL);
 
+		testGetLayoutRelativeURL(
+			initThemeDisplay(company, group, publicLayout, COMPANY_HOSTNAME,
+				LAYOUT_HOSTNAME),
+			publicLayout, publicLayoutRelativeURL);
+
 		String publicLayoutFriendlyURL = publicLayout.getFriendlyURL();
 		String layoutRelativeURL = PortalUtil.getLayoutRelativeURL(
 			publicLayout,
@@ -110,6 +115,10 @@ public class PortalImplLayoutRelativeURLTest extends BasePortalImplURLTestCase {
 		catch (NoSuchLayoutException nsle) {
 		}
 	}
+
+	protected static final String COMPANY_HOSTNAME = "myinstance.com";
+
+	protected static final String LAYOUT_HOSTNAME = "mysite.com";
 
 	protected String privateLayoutRelativeURL;
 	protected String publicLayoutRelativeURL;


### PR DESCRIPTION
Hey @ericyanLr 

Thank you your suggestion [here](https://issues.liferay.com/browse/PTR-753?focusedCommentId=1796225&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1796225), I managed to add a test case of site scoped layout with separate instance and site host names.
Please note that I was not necessary to create a further layout, since publicLayout is already create based on a Site Group, see https://github.com/liferay/liferay-portal/blob/master/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java#L109.

Could you please check it?

Thank you and best regards,
István