### PR TITLE
LPS-96930 Forwarded host doesn't get applied when using site virtual hosts

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8523,6 +8523,10 @@ public class PortalImpl implements Portal {
 								virtualHostname, _LOCALHOST) &&
 							!_isSameHostName(virtualHostname, portalDomain)) {
 
+							if (PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED) {
+								virtualHostname = portalDomain;
+							}
+
 							portalURL = getPortalURL(
 								virtualHostname, themeDisplay.getServerPort(),
 								themeDisplay.isSecure());


### PR DESCRIPTION
[LPS-96930](https://issues.liferay.com/browse/LPS-96930)

Hi Eric,

I hope you can review my changes.

**Issue**
Forwarded host doesn't get applied for canonical URLs when using site virtual hosts.

**Analysis**
The incorrect URLs are generated by _PortalImpl._getGroupFriendlyURL(Group group, LayoutSet layoutSet, ThemeDisplay themeDisplay, boolean canonicalURL, boolean controlPanel)_.

The problem here, as I see, is the false assumption that if defined, we should always use the _virtualHostname_ instead of _portalDomain_ to generate canonical URLs (actually group friendly URL). 

The purpose of the forwarded host header (if enabled) is to tell the portal which value to use when generating URLs. In _ServicePreAction.initThemeDisplay()_ we see that the _portalURL_, _portalDomain_ and _serverName_ values in themeDisplay are set with correct host value, because _PortalUtil.getPortalURL(httpServletRequest)_ takes the forwarded host into account.

// Portal URL

```
String portalURL = PortalUtil.getPortalURL(httpServletRequest);
...
themeDisplay.setPortalDomain(_getPortalDomain(portalURL));
themeDisplay.setPortalURL(portalURL);
...
themeDisplay.setServerName(
  PortalUtil.getForwardedHost(httpServletRequest));
```

**Conclusion**

When generating the group friendly URL, if the forwarded host header is enabled, we should use the _portalDomain_ value (coming from themeDisplay).

FYI, based on manual test and CI tests my changes are safe, but I am not an expert in how we generate URLs, so I really appreciate any help.

Please let me know if you have any concerns.

Thank you,
Istvan