### PR TITLE
LPS-96930 Forwarded host doesn't get applied when using site virtual hosts

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7636,7 +7636,8 @@ public class PortalImpl implements Portal {
 
 		if (Validator.isBlank(portalDomain) ||
 			StringUtil.equalsIgnoreCase(portalDomain, _LOCALHOST) ||
-			!StringUtil.equalsIgnoreCase(virtualHostname, _LOCALHOST)) {
+			(!StringUtil.equalsIgnoreCase(virtualHostname, _LOCALHOST) &&
+			 !PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED)) {
 
 			return virtualHostname;
 		}
@@ -8522,6 +8523,9 @@ public class PortalImpl implements Portal {
 						if (!StringUtil.equalsIgnoreCase(
 								virtualHostname, _LOCALHOST) &&
 							!_isSameHostName(virtualHostname, portalDomain)) {
+
+							virtualHostname = getCanonicalDomain(
+								virtualHostname, portalDomain);
 
 							portalURL = getPortalURL(
 								virtualHostname, themeDisplay.getServerPort(),


### PR DESCRIPTION
[LPS-96930](https://issues.liferay.com/browse/LPS-96930)

Hi Eric,

I am resending this as investigating [your concerns](https://github.com/ericyanLr/liferay-portal/pull/125#issuecomment-503366399) had the following outcome:
- getCanonicalDomain seems to be indeed a better place for my addition.
- My changes passed manual testing for both [LPS-72481](https://issues.liferay.com/browse/LPS-72481) and [LPS-69799](https://issues.liferay.com/browse/LPS-69799).

**Issue**
Forwarded host doesn't get applied for canonical URLs when using site virtual hosts.

**Analysis**
The incorrect URLs are generated by _PortalImpl._getGroupFriendlyURL(Group group, LayoutSet layoutSet, ThemeDisplay themeDisplay, boolean canonicalURL, boolean controlPanel)_.

The problem here, as I see, is the false assumption that if defined, we should always use the _virtualHostname_ instead of _portalDomain_ to generate canonical URLs. 

The purpose of the forwarded host header (if enabled) is to tell the portal which value to use when generating URLs. In _ServicePreAction.initThemeDisplay()_ we see that the _portalURL_, _portalDomain_ and _serverName_ values in themeDisplay are set with correct host value, because _PortalUtil.getPortalURL(httpServletRequest)_ takes the forwarded host into account.

// Portal URL

```
String portalURL = PortalUtil.getPortalURL(httpServletRequest);
...
themeDisplay.setPortalDomain(_getPortalDomain(portalURL));
themeDisplay.setPortalURL(portalURL);
...
themeDisplay.setServerName(
  PortalUtil.getForwardedHost(httpServletRequest));
```

**Conclusion**

When generating the group friendly URL, if the forwarded host header is enabled, we should use the _portalDomain_ value (coming from themeDisplay).

Please let me know if you have any further concerns.

Thank you,
Istvan