### PR TITLE
LPS-84320

### DIFF
--- a/portal-impl/src/com/liferay/mail/messaging/MailMessageListener.java
+++ b/portal-impl/src/com/liferay/mail/messaging/MailMessageListener.java
@@ -17,6 +17,7 @@ package com.liferay.mail.messaging;
 import com.liferay.mail.kernel.model.MailMessage;
 import com.liferay.mail.util.HookFactory;
 import com.liferay.petra.mail.MailEngine;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
@@ -119,8 +120,23 @@ public class MailMessageListener extends BaseMessageListener {
 		EmailAddressGenerator emailAddressGenerator =
 			EmailAddressGeneratorFactory.getInstance();
 
-		if (emailAddressGenerator.isFake(internetAddress.getAddress())) {
+		String emailAddress = internetAddress.getAddress();
+
+		if (emailAddressGenerator.isFake(emailAddress)) {
 			return null;
+		}
+
+		for (String blacklistedEmail : PropsValues.MAIL_SEND_BLACKLIST) {
+			if (emailAddress.endsWith(blacklistedEmail)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Email ", emailAddress, " will be ignored as it",
+							"is included in mail.send.blacklist"));
+				}
+
+				return null;
+			}
 		}
 
 		return internetAddress;

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1732,6 +1732,9 @@ public class PropsValues {
 	public static final boolean MAIL_MX_UPDATE = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.MAIL_MX_UPDATE));
 
+	public static final String[] MAIL_SEND_BLACKLIST = PropsUtil.getArray(
+		PropsKeys.MAIL_SEND_BLACKLIST);
+
 	public static final boolean MAIL_SESSION_MAIL = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.MAIL_SESSION_MAIL));
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.6.0
+version 3.7.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -10310,7 +10310,7 @@
     # Env: LIFERAY_ADMIN_PERIOD_EMAIL_PERIOD_FROM_PERIOD_NAME
     #
     admin.email.from.name=Joe Bloggs
-    admin.email.from.address=test@liferay.com
+    admin.email.from.address=test@domain.invalid
 
     #
     # Env: LIFERAY_ADMIN_PERIOD_EMAIL_PERIOD_USER_PERIOD_ADDED_PERIOD_ENABLED
@@ -10377,7 +10377,7 @@
     # Env: LIFERAY_ANNOUNCEMENTS_PERIOD_EMAIL_PERIOD_TO_PERIOD_NAME
     #
     announcements.email.to.name=
-    announcements.email.to.address=noreply@liferay.com
+    announcements.email.to.address=noreply@domain.invalid
 
     #
     # Env: LIFERAY_ANNOUNCEMENTS_PERIOD_EMAIL_PERIOD_BODY

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7579,6 +7579,15 @@
     mail.batch.size=0
 
     #
+    # Input a list of comma delimited email addresses or email domains that will
+    # be blacklisted during send operation. Email address will be ignored and a
+    # warning will be traced in log file.
+    #
+    # Env: LIFERAY_MAIL_PERIOD_SEND_PERIOD_BLACKLIST
+    #
+    mail.send.blacklist=test@liferay.com,@example.com,@domain.invalid
+
+    #
     # Set the JNDI name to lookup the Java Mail session. If none is set, then
     # the portal will attempt to create the Java Mail session based on the
     # properties prefixed with "mail.session.".

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2006,6 +2006,8 @@ public interface PropsKeys {
 
 	public static final String MAIL_MX_UPDATE = "mail.mx.update";
 
+	public static final String MAIL_SEND_BLACKLIST = "mail.send.blacklist";
+
 	public static final String MAIL_SESSION_MAIL = "mail.session.mail";
 
 	public static final String MAIL_SESSION_MAIL_ADVANCED_PROPERTIES =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.10.0
+version 9.11.0

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -100,7 +100,7 @@
 
 								<%@ include file="/html/portal/setup_wizard_user_name.jspf" %>
 
-								<aui:input label="email" name="adminEmailAddress" value="<%= PropsValues.ADMIN_EMAIL_FROM_ADDRESS %>">
+								<aui:input label="email" name="adminEmailAddress">
 									<aui:validator name="email" />
 									<aui:validator name="required" />
 								</aui:input>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84320

To avoid sending mail when sender is unconfigured (e.g. test@liferay.com) this PR does following changes:
- **First commit https://github.com/ericyanLr/liferay-portal/pull/134/commits/a3618aea5e07040721816a2e11cc16ecc0ba89bf -** In SetupWizard, I have removed default email value, so customers cannot simply accept default "test@liferay.com" and they have to fill a valid email
- **Second commit https://github.com/ericyanLr/liferay-portal/pull/134/commits/5caf27fbbca94bc98e7f16402dcdde44170b9e2c -** In portal.properties, I have replaced "test@liferay.com" and "noreply@liferay.com" with  "test@domain.invalid" and "noreply@domain.invalid", so if customers don't execute the SetupWizard, they don't have "test@liferay.com" and they will have an [invalid eamil](https://tools.ietf.org/html/rfc2606). We cannot leave it empty as it will break some tests.
- **Third commit https://github.com/ericyanLr/liferay-portal/pull/134/commits/a6c796d6412fe34ab305a50ede551c30976e533d -** In case we have an old customer that already have "test@liferay.com" in its installation, I am adding a email blacklist before email is sent, so we will stop any wrong email from being send in case they have the default configuration. 
