### PR TITLE
LPS-84320

### DIFF
--- a/portal-impl/src/com/liferay/mail/messaging/MailMessageListener.java
+++ b/portal-impl/src/com/liferay/mail/messaging/MailMessageListener.java
@@ -17,6 +17,7 @@ package com.liferay.mail.messaging;
 import com.liferay.mail.kernel.model.MailMessage;
 import com.liferay.mail.util.HookFactory;
 import com.liferay.petra.mail.MailEngine;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
@@ -29,6 +30,7 @@ import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.mail.internet.InternetAddress;
 
@@ -119,8 +121,23 @@ public class MailMessageListener extends BaseMessageListener {
 		EmailAddressGenerator emailAddressGenerator =
 			EmailAddressGeneratorFactory.getInstance();
 
-		if (emailAddressGenerator.isFake(internetAddress.getAddress())) {
+		String emailAddress = internetAddress.getAddress();
+
+		if (emailAddressGenerator.isFake(emailAddress)) {
 			return null;
+		}
+
+		for (String blacklistedEmail : PropsValues.MAIL_SEND_BLACKLIST) {
+			if (Objects.equals(emailAddress, blacklistedEmail)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Email ", emailAddress, " will be ignored as it",
+							"is included in mail.send.blacklist"));
+				}
+
+				return null;
+			}
 		}
 
 		return internetAddress;

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1732,6 +1732,9 @@ public class PropsValues {
 	public static final boolean MAIL_MX_UPDATE = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.MAIL_MX_UPDATE));
 
+	public static final String[] MAIL_SEND_BLACKLIST = PropsUtil.getArray(
+		PropsKeys.MAIL_SEND_BLACKLIST);
+
 	public static final boolean MAIL_SESSION_MAIL = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.MAIL_SESSION_MAIL));
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.6.0
+version 3.7.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7579,6 +7579,15 @@
     mail.batch.size=0
 
     #
+    # Input a list of comma delimited email addresses that will be blacklisted
+    # during send operation. Email address will be ignored and a warning will be
+    # traced in log file.
+    #
+    # Env: LIFERAY_MAIL_PERIOD_SEND_PERIOD_BLACKLIST
+    #
+    mail.send.blacklist=test@liferay.com
+
+    #
     # Set the JNDI name to lookup the Java Mail session. If none is set, then
     # the portal will attempt to create the Java Mail session based on the
     # properties prefixed with "mail.session.".

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2006,6 +2006,8 @@ public interface PropsKeys {
 
 	public static final String MAIL_MX_UPDATE = "mail.mx.update";
 
+	public static final String MAIL_SEND_BLACKLIST = "mail.send.blacklist";
+
 	public static final String MAIL_SESSION_MAIL = "mail.session.mail";
 
 	public static final String MAIL_SESSION_MAIL_ADVANCED_PROPERTIES =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.10.0
+version 9.11.0

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -100,7 +100,7 @@
 
 								<%@ include file="/html/portal/setup_wizard_user_name.jspf" %>
 
-								<aui:input label="email" name="adminEmailAddress" value="<%= PropsValues.ADMIN_EMAIL_FROM_ADDRESS %>">
+								<aui:input label="email" name="adminEmailAddress">
 									<aui:validator name="email" />
 									<aui:validator name="required" />
 								</aui:input>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-84320

Same code than https://github.com/ericyanLr/liferay-portal/pull/134 but I have done some changes:

- Removed commit with `admin.email.from.address` and `announcements.email.to.address` changes
- Modified last commit, now I am doing `Objects.equals` instead of `.endsWith`, so now only specific email addresses are blocked

About your comment in https://github.com/ericyanLr/liferay-portal/pull/134
> 3rd Commit - Simplification
> From my understanding, the main fix is blacklisting the email address: test@liferay.com
> Would adding a simple implementation to block the email address: test@liferay.com, be sufficient?

As I said above,  I have removed the email-domain block code and only specific email addresses will be blocked.

I don't think it is a good idea to block "test@liferay.com" inside java code:

1. It is a bad idea to hard-code test@liferay.com address in java code.
2. We should allow customers to revert "test@liferay.com" blacklist to avoid complains from existing customers.
3. Having a property in *portal.properties* will also allow blocking other email addresses in case it is necessary.

Thank you