### PR TITLE
LPS-103247 frontend-js-aui-web: Update localized field with default language value when empty language value when empty

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -135,6 +135,22 @@ AUI.add(
 			NAME: 'input-localized',
 
 			prototype: {
+				_afterVal() {
+					var instance = this;
+
+					var currentValue = instance.getValue(
+						instance.getSelectedLanguageId()
+					);
+
+					if (currentValue === '') {
+						const defaultValue = instance.getValue(
+							defaultLanguageId
+						);
+
+						instance.updateInput(defaultValue);
+					}
+				},
+
 				_animate(input, shouldFocus) {
 					var instance = this;
 
@@ -485,6 +501,10 @@ AUI.add(
 						Liferay.on(
 							'inputLocalized:localeChanged',
 							A.bind('_onLocaleChanged', instance)
+						),
+						Liferay.on(
+							'inputLocalized:localeChanged',
+							A.bind('_afterVal', instance)
 						),
 						Liferay.on(
 							'submitForm',


### PR DESCRIPTION


LPP Ticket Link: https://issues.liferay.com/browse/LPP-35342
PTR Ticket Link: https://issues.liferay.com/browse/PTR-1262
LPS Ticket Link: https://issues.liferay.com/browse/LPS-103247

- Traced the root of the bug to the input_localized.js file and implemented the _afterVal() and A.Do.after() functions from the POC
    - Stepped through the bug to see if it would fix the required title bug on click of Save
        - When Save is clicked after changing the language, the required title is no longer required and allows the user to Save, taking them back to the ‘Site Builder > Pages’ screen
- Additional Bug found
    - When user changes language on ‘General > Title’ screen and clicks Save, it takes them back to the ‘Site Builder > Pages’ screen but does not save the updated title when selecting the corresponding language
    - Tested on original code, without added _afterVal() and A.Do.after() functions and it updated the corresponding language titles correctly.  
- Summary
    - Adding the additional functions fixes the ‘Save’ bug, which required a title to be entered after changing the language, but an additional bug was added, which will not save the corresponding language title
- Looked for similar files using the Liferay.on(‘input:localization:localeChanged’,...)` function, since this was the core logic/fix that needed to be implemented
    - Found that JournalPortlet.es.js most closely resembled the logic similar to input_localized.js
        - ![image](https://user-images.githubusercontent.com/46731133/69465681-aa03eb00-0d36-11ea-8802-d1ab487e84a0.png)

    - Traced through the _onLocalChange(event) function, which brought me to the _updateLanguageIdInput(selectedLanguageId) function
        - Extracted the logic from the function conditional stating that if the inputSelectedValue is empty, set the inputDefaultValue to the defaultLanguageId.  Once set, update the Input with the inputDefaultValue so that the field is no longer blank.  This fixed the additional bug after implementing the _afterVal() function, since the input was not being repopulated with the input default value, causing it to not save anything after updating the language Id.
            - ![image](https://user-images.githubusercontent.com/46731133/69465716-be47e800-0d36-11ea-828a-595a553e30a6.png)

    - After implementing JournalPortlet.es.js input:localization:localChanged logic in to original _afterVal() function in input_localized.js, set breakpoint in _afterVal() to test	
        - ![image](https://user-images.githubusercontent.com/46731133/69465739-cef85e00-0d36-11ea-88eb-421103a7fa16.png)

    - Logged out what this._getSrcNode() was producing to see the output that was being populated in each input field compared to before
        - ![image](https://user-images.githubusercontent.com/46731133/69465745-d586d580-0d36-11ea-86df-1a746b2ba884.png)

- Tested & Working
    - Created before/after video's in LPP-35342 ticket

