### PR TITLE
LPS-106585 isValidForward when the path is starting with a forward slash

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -509,7 +509,9 @@ public class FriendlyURLServlet extends HttpServlet {
 
 			String path = getPath();
 
-			if (path.equals(Portal.PATH_MAIN) || path.startsWith("/c/")) {
+			if ((path.charAt(0) == CharPool.SLASH) ||
+				path.equals(Portal.PATH_MAIN) || path.startsWith("/c/")) {
+
 				return true;
 			}
 


### PR DESCRIPTION
Hi @ericyanLr 

could you please check my changes and push it forward?

Thanks, Roland

https://issues.liferay.com/browse/LPS-106585