### PR TITLE
LPS-111354

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
@@ -41,6 +41,7 @@ import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.Cas20ProxyTicketValidator;
+import org.jasig.cas.client.validation.TicketValidationException;
 import org.jasig.cas.client.validation.TicketValidator;
 
 import org.osgi.service.component.annotations.Component;
@@ -238,7 +239,20 @@ public class CASFilter extends BaseFilter {
 
 		TicketValidator ticketValidator = getTicketValidator(companyId);
 
-		Assertion assertion = ticketValidator.validate(ticket, serviceURL);
+		Assertion assertion = null;
+
+		try {
+			assertion = ticketValidator.validate(ticket, serviceURL);
+		}
+		catch (TicketValidationException ticketValidationException) {
+			_log.error(ticketValidationException, ticketValidationException);
+
+			processFilter(
+				CASFilter.class.getName(), httpServletRequest,
+				httpServletResponse, filterChain);
+
+			return;
+		}
 
 		if (assertion != null) {
 			AttributePrincipal attributePrincipal = assertion.getPrincipal();

--- a/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
@@ -221,7 +221,7 @@ public class CASFilter extends BaseFilter {
 		if (Validator.isNull(serviceURL)) {
 			serviceURL = CommonUtils.constructServiceUrl(
 				httpServletRequest, httpServletResponse, serviceURL, serverName,
-				"ticket", false);
+				"ticket", true);
 		}
 
 		String ticket = ParamUtil.getString(httpServletRequest, "ticket");

--- a/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java
@@ -221,7 +221,7 @@ public class CASFilter extends BaseFilter {
 		if (Validator.isNull(serviceURL)) {
 			serviceURL = CommonUtils.constructServiceUrl(
 				httpServletRequest, httpServletResponse, serviceURL, serverName,
-				"ticket", true);
+				"service", "ticket", true);
 		}
 
 		String ticket = ParamUtil.getString(httpServletRequest, "ticket");


### PR DESCRIPTION
**Issues**

1. Liferay shows a blank page when a CAS exception is throwing during ticket validation, specifically at this line: 
    - `assertion = ticketValidator.validate(ticket, serviceURL);`
2. Liferay has pretty complex URL parameters, such as portlet redirect URLs. These URLs are not properly passed via a **redirect** URL parameter, along to CAS and back to Liferay.
    - e.g. Navigating to Web Content > New(+) > Basic Web Content
        - URL: http://localhost:8080/group/guest/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fedit_article.jsp&_com_liferay_journal_web_portlet_JournalPortlet_redirect=%2Fgroup%2Fguest%2F~%2Fcontrol_panel%2Fmanage%3Fp_p_id%3Dcom_liferay_journal_web_portlet_JournalPortlet%26p_p_lifecycle%3D0%26p_p_state%3Dmaximized%26p_v_l_s_g_id%3D20121%26p_p_auth%3Dkr0xIRG9&_com_liferay_journal_web_portlet_JournalPortlet_groupId=20121&_com_liferay_journal_web_portlet_JournalPortlet_folderId=0&_com_liferay_journal_web_portlet_JournalPortlet_ddmStructureKey=BASIC-WEB-CONTENT&p_p_auth=kcQuXg03
        - Note: `_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fedit_article.jsp`

**Proposed Fix**
This proposed fix handles **issue1** by introducing a try/catch block, which is pretty straight-forward.

As for **issue2**, it turns out we do not properly encode our URL parameters when creating our serviceURL, before sending the URL to CAS.

For example, the mentioned: 
`_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fedit_article.jsp`

- The **%2Fedit_article.jsp** is not converted to **%252Fedit_article.jsp**

To resolve this, we make sure to encode the URL parameters be simply setting the the encode parameter to true for :
```
serviceURL = CommonUtils.constructServiceUrl(
    httpServletRequest, httpServletResponse, serviceURL, serverName,
    "service", "ticket", true);
```