### PR TITLE
[TS] LPS-114409 InvocationTargetException occurs during Liferay startup if there is a subfolder in osgi\configs

### DIFF
--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -1279,7 +1279,9 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		dir = dir.getCanonicalFile();
 
 		for (File file : dir.listFiles()) {
-			method.invoke(configInstaller, file);
+			if (file.isFile()) {
+				method.invoke(configInstaller, file);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @ericyanLr ,
Please review my fix, and if you approve this change, please forward it to the next approver,
Thank you,
Peter