### PR TITLE
LPS-115661

### DIFF
--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -4005,7 +4005,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>A design type for the tabs. Possible values are <![CDATA[<code>tabs</code>]]> and <![CDATA[<code>pills</code>]]>.</description>
+			<description>A design type for the tabs. Possible values are <![CDATA[<code>tabs</code>]]>, <![CDATA[<code>underline</code>]]>, <![CDATA[<code>stacked</code>]]>, <![CDATA[<code>justified</code>]]>, <![CDATA[<code>dropdown</code>]]> and <![CDATA[<code>pills</code>]]>.</description>
 			<name>type</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-115661

Solution to this is to use `underline` instead of `tabs`, but `underline` wasn't included in the documentation for the tag library. Also found a bunch of other options inside of [_navs.scss](https://github.com/liferay/liferay-portal/blob/7.3.2-ga3/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_navs.scss), and so we're including them in the documentation.