### PR TITLE
[TS] LPS-88338

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -186,9 +186,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			ActionResponse actionResponse)
 		throws Exception {
 
-		HttpServletRequest httpServletRequest =
-			_portal.getOriginalServletRequest(
-				_portal.getHttpServletRequest(actionRequest));
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			actionRequest);
 
 		if (!themeDisplay.isSignedIn()) {
 			HttpServletResponse httpServletResponse =

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdatePasswordMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdatePasswordMVCActionCommand.java
@@ -147,8 +147,7 @@ public class UpdatePasswordMVCActionCommand extends BaseMVCActionCommand {
 				}
 
 				_authenticatedSessionManager.login(
-					_portal.getOriginalServletRequest(
-						_portal.getHttpServletRequest(actionRequest)),
+					_portal.getHttpServletRequest(actionRequest),
 					_portal.getHttpServletResponse(actionResponse), login,
 					newPassword1, false, null);
 			}

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.12.3
+Bundle-Version: 5.13.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -86,10 +87,18 @@ public class AuthenticatedSessionManagerImpl
 			String password, boolean rememberMe, String authType)
 		throws Exception {
 
+		String queryString = null;
+
+		if (PortalUtil.isForwarded(httpServletRequest)) {
+			queryString = (String)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_SERVLET_FORWARD_QUERY_STRING);
+		}
+		else {
+			queryString = httpServletRequest.getQueryString();
+		}
+
 		httpServletRequest = PortalUtil.getOriginalServletRequest(
 			httpServletRequest);
-
-		String queryString = httpServletRequest.getQueryString();
 
 		if (Validator.isNotNull(queryString) &&
 			queryString.contains("password=")) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6166,6 +6166,18 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
+	public boolean isForwarded(HttpServletRequest httpServletRequest) {
+		String requestURI = (String)httpServletRequest.getAttribute(
+			JavaConstants.JAVAX_SERVLET_FORWARD_REQUEST_URI);
+
+		if (requestURI != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean isForwardedSecure(HttpServletRequest httpServletRequest) {
 		if (PropsValues.WEB_SERVER_FORWARDED_PROTOCOL_ENABLED) {
 			String forwardedProtocol = httpServletRequest.getHeader(

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 8.2.0
+Bundle-Version: 8.3.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1148,6 +1148,8 @@ public interface Portal {
 
 	public boolean isCustomPortletMode(PortletMode portletMode);
 
+	public boolean isForwarded(HttpServletRequest httpServletRequest);
+
 	public boolean isForwardedSecure(HttpServletRequest httpServletRequest);
 
 	public boolean isGroupAdmin(User user, long groupId) throws Exception;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1893,6 +1893,10 @@ public class PortalUtil {
 		return getPortal().isCustomPortletMode(portletMode);
 	}
 
+	public static boolean isForwarded(HttpServletRequest httpServletRequest) {
+		return getPortal().isForwarded(httpServletRequest);
+	}
+
 	public static boolean isForwardedSecure(
 		HttpServletRequest httpServletRequest) {
 


### PR DESCRIPTION
[LPS-88338](https://issues.liferay.com/browse/LPS-88338)

Hi Eric,

I hope you can review my changes. 

We were talking about the issue in the past in frame of [PTR-725](https://issues.liferay.com/browse/PTR-725). Sorry for sending the PR only after such a long time, but eliminating certain test failures caused some headache for me.

**Issue:**
In short, the check introduced by [LPS-71409](https://issues.liferay.com/browse/LPS-71409) doesn't work on Wildfly / JBoss EAP/ WebSphere because we don't follow the [Servlet 3 specification](https://download.oracle.com/otn-pub/jcp/servlet-3.0-fr-eval-oth-JSpec/servlet-3_0-final-spec.pdf) when accessing the originally sent request parameters on dispatched requests. (Dispatched requests may have different parameters than the original.)

Using the PortalUtil.getOriginalServletRequest(HttpServletRequest) to access the properties of the request originally sent from the browser is a wrong approach.

**Technical Background:**
The issue originates from the incorrect assumption that PortalImpl.getOriginalServletRequest(HttpServletRequest) returns the "original request" carrying the URL, query string, etc. as it comes from the browser.

The request (in recent scenario a RenderRequest) we want to use to retrieve the original URL and query string is wrapped multiple times and went through several RequestDispatchers. I found no info in [Servlet 3 specification](https://download.oracle.com/otn-pub/jcp/servlet-3.0-fr-eval-oth-JSpec/servlet-3_0-final-spec.pdf) what to expect from the current approach of unwrapping the "original request" (in PortalImpl.getOriginalServletRequest(HttpServletRequest)). I found, however, the description of how to access the properties of the "original request" (facing the very first servlet) in case of forwarded/included requests.

> 9.3.1 Included Request Parameters
> 
> ...
> 
> The following request attributes must be set:
> 
> javax.servlet.include.request_uri
> javax.servlet.include.context_path
> javax.servlet.include.servlet_path
> javax.servlet.include.path_info
> javax.servlet.include.query_string
> 
> These attributes are accessible from the included servlet via the getAttribute method on the request object and their values must be equal to the request URI, context path, servlet path, path info, and query string of the included servlet, respectively. If the request is subsequently included, these attributes are replaced for that include.

> 9.4.2 Forwarded Request Parameters
> 
> ...
> 
> The following request attributes must be set:
> 
> javax.servlet.forward.request_uri
> javax.servlet.forward.context_path
> javax.servlet.forward.servlet_path
> javax.servlet.forward.path_info
> javax.servlet.forward.query_string
> 
> The values of these attributes must be equal to the return values of the HttpServletRequest methods getRequestURI, getContextPath, getServletPath, getPathInfo, getQueryString respectively, invoked on the request object passed to the first servlet object in the call chain that received the request from the client.
> These attributes are accessible from the forwarded servlet via the getAttribute method on the request object. Note that these attributes must always reflect the information in the original request even under the situation that multiple forwards and subsequent includes are called.

**How I understand the spec:**
If the request was forwarded, then the properties (request URI, context path, servlet path, path_info, query_string) of the originally sent request are preserved by the javax.servlet.forward.* attributes. For included request we can call the getter methods directly on the request as they return the values belonging to the originally sent request. That is, we have to handle distinctively only the case of forwarded requests.

**FYI**, LPS-94230 had basically the same root cause and I used the same approach to fix it.

Please let me know what you think about my changes.

Thank you,
István
