### PR TITLE
LPS-116291: portletResource only use in case PortletConfiguration for referencing the right portlet

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortletKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortletKeys.java
@@ -139,6 +139,10 @@ public class PortletKeys {
 	public static final String PORTAL_SETTINGS =
 		"com_liferay_portal_settings_web_portlet_PortalSettingsPortlet";
 
+	public static final String PORTLET_CONFIGURATION =
+		"com_liferay_portlet_configuration_web_portlet_" +
+			"PortletConfigurationPortlet";
+
 	public static final String PORTLET_DISPLAY_TEMPLATE =
 		"com_liferay_dynamic_data_mapping_web_portlet_" +
 			"PortletDisplayTemplatePortlet";

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -160,10 +160,14 @@ String responseContentType = liferayRenderRequest.getResponseContentType();
 
 String currentURL = PortalUtil.getCurrentURL(request);
 
-String portletResource = ParamUtil.getString(request, "portletResource");
+String portletResource = StringPool.BLANK;
 
-if (Validator.isNull(portletResource)) {
-	portletResource = ParamUtil.getString(liferayRenderRequest, "portletResource");
+if (PortletKeys.PORTLET_CONFIGURATION.equals(portletId)) {
+	portletResource = ParamUtil.getString(request, "portletResource");
+
+	if (Validator.isNull(portletResource)) {
+		portletResource = ParamUtil.getString(liferayRenderRequest, "portletResource");
+	}
 }
 
 Portlet portletResourcePortlet = null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-116291

From @holatuwol

> From @binhtran92
> 
> > I found that the `portletResource` was introduced because the `PortletConfiguration` is loaded from different porlet. So they need that param to get preferences from the right portlet, as said from ticket https://issues.liferay.com/browse/LPS-44445.
> > 
> > However, I think when doing the refactor dependency at ticket https://issues.liferay.com/browse/LPS-55833, the author may assume that the PortletConfiguration is on all plugins (Portal and Market) then he decided to remove the condition.
> > 
> > So, my solution is, only set the portletResource if the portlet is PortletConfiguration. If not, just leave it as it is like the time this param was introduced.
> 
> Looking through the code base, the only places where we create a URL with the `portletResource` parameter are the following portlets, derived with the following bash script:
> 
> ```bash
> git ls-files modules | tr '\n' '\0' | xargs -0 grep -Fl 'setParameter("portletResource"' | sed 's@/src/.*$@@g' | uniq
> ```
> 
> * modules/apps/asset/asset-publisher-web
> * modules/apps/blogs/blogs-web
> * modules/apps/bookmarks/bookmarks-web
> * modules/apps/document-library/document-library-web
> * modules/apps/export-import/export-import-changeset-taglib
> * modules/apps/export-import/export-import-web
> * modules/apps/journal/journal-content-web
> * modules/apps/journal/journal-web
> * modules/apps/layout/layout-admin-web
> * modules/apps/layout/layout-content-page-editor-web
> * modules/apps/plugins-admin/plugins-admin-web
> * modules/apps/portal-workflow/portal-workflow-task-web
> * modules/apps/portlet-configuration/portlet-configuration-css-web
> * modules/apps/portlet-configuration/portlet-configuration-web
> * modules/apps/roles/roles-admin-web
> 
> There were a lot of matches, so I asked @binhtran92 to double-check these to make sure that there wasn't an accidental regression. According to his investigation, there shouldn't be any downstream effects from this change.
> 
> From @binhtran92
> 
> > I have review many class related to `git ls-files | tr '\n' '\0' | xargs -0 grep -F 'setParameter("portletResource"'`. As I know currently `portletResource` using in many purpose. Mostly using for notify the message. Methods using for URL adding the `portletResource` is indicate that where this url come from.
> 
> One of the other things that this change may affect is anything using `PortletDisplay.getPortletResource()`, which was also checked:
> 
> From @binhtran92
> 
> > Our solution mainly related to features which are using the `portletDisplay` then I using `git ls-files | tr '\n' '\0' | xargs -0 grep -F 'portletDisplay.getPortletResource()`, I go through these classes and I can see all classes is related to the Configuration Portlet
> 
> In this case, they were either directly tied to a configuration path (configuration was part of the package path), or in the case of `JournalWebRequestHelper`, were only invoked by a configuration class.