### PR TITLE
[TS] LPS-118579 MB: Nullpointer when clickin on Advanced Reply

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -24,8 +24,8 @@ Boolean editable = (Boolean)request.getAttribute("edit_message.jsp-editable");
 MBMessage message = (MBMessage)request.getAttribute("edit_message.jsp-message");
 Boolean showPermanentLink = (Boolean)request.getAttribute("edit-message.jsp-showPermanentLink");
 Boolean showRecentPosts = (Boolean)request.getAttribute("edit-message.jsp-showRecentPosts");
-MBThread thread = (MBThread)request.getAttribute("edit_message.jsp-thread");
-
+long threadId = BeanParamUtil.getLong(message, request, "threadId");
+MBThread thread = MBThreadLocalServiceUtil.getThread(threadId);
 if (message.isAnonymous() || thread.isInTrash()) {
 	showRecentPosts = false;
 }


### PR DESCRIPTION
The issue was that the thread could not be assigned using `request.getAttribute`.  This would give an NPE.  I used the same request and message to get the `threadID `using `BeanParamUtil.getLong()` and created the thread with `MBThreadLocalServiceUtil.getThread`.