### PR TITLE
[TECHNICAL SUPPORT] LPS-118579 MB: Nullpointer when clickin on Advanced Reply

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -30,11 +30,10 @@ long parentMessageId = BeanParamUtil.getLong(message, request, "parentMessageId"
 String subject = BeanParamUtil.getString(message, request, "subject");
 
 MBThread thread = null;
-
 MBMessage curParentMessage = null;
-
 if (threadId > 0) {
 	try {
+		thread = MBThreadLocalServiceUtil.getThread(threadId);
 		curParentMessage = MBMessageServiceUtil.getMessage(parentMessageId);
 
 		if (Validator.isNull(subject)) {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -24,8 +24,8 @@ Boolean editable = (Boolean)request.getAttribute("edit_message.jsp-editable");
 MBMessage message = (MBMessage)request.getAttribute("edit_message.jsp-message");
 Boolean showPermanentLink = (Boolean)request.getAttribute("edit-message.jsp-showPermanentLink");
 Boolean showRecentPosts = (Boolean)request.getAttribute("edit-message.jsp-showRecentPosts");
-MBThread thread = (MBThread)request.getAttribute("edit_message.jsp-thread");
-
+long threadId = BeanParamUtil.getLong(message, request, "threadId");
+MBThread thread = MBThreadLocalServiceUtil.getThread(threadId);
 if (message.isAnonymous() || thread.isInTrash()) {
 	showRecentPosts = false;
 }

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -24,8 +24,8 @@ Boolean editable = (Boolean)request.getAttribute("edit_message.jsp-editable");
 MBMessage message = (MBMessage)request.getAttribute("edit_message.jsp-message");
 Boolean showPermanentLink = (Boolean)request.getAttribute("edit-message.jsp-showPermanentLink");
 Boolean showRecentPosts = (Boolean)request.getAttribute("edit-message.jsp-showRecentPosts");
-long threadId = BeanParamUtil.getLong(message, request, "threadId");
-MBThread thread = MBThreadLocalServiceUtil.getThread(threadId);
+MBThread thread = (MBThread)request.getAttribute("edit_message.jsp-thread");
+
 if (message.isAnonymous() || thread.isInTrash()) {
 	showRecentPosts = false;
 }


### PR DESCRIPTION
The original fix was erroneous due to the fact that multiple JSP files retrieve the thread using the same request.getAttribute().  The fix was applied in the try-catch statement where threadID is checked to see if it is greater than one.