### PR TITLE
[TS]LPS-118579 message-boards-web: Changed thread declaration

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -35,6 +35,7 @@ MBMessage curParentMessage = null;
 
 if (threadId > 0) {
 	try {
+		thread = MBThreadLocalServiceUtil.getThread(threadId);
 		curParentMessage = MBMessageServiceUtil.getMessage(parentMessageId);
 
 		if (Validator.isNull(subject)) {
@@ -332,7 +333,6 @@ if (portletTitleBasedNavigation) {
 					String displayStyle = category.getDisplayStyle();
 
 					if (message != null) {
-						thread = MBThreadLocalServiceUtil.getThread(threadId);
 
 						if (thread.isQuestion() || message.isAnswer()) {
 							question = true;


### PR DESCRIPTION
The issue was the thread is initialized at a point where it is still considered null when used by other JSPs.  The issue is fix by moving thread initialization where threadID is validated.  