### PR TITLE
[TS] LPS-118579 message-board-web: MB: Nullpointer when clickin on Advanced Reply

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -34,6 +34,8 @@ MBThread thread = null;
 MBMessage curParentMessage = null;
 
 if (threadId > 0) {
+	thread = MBThreadLocalServiceUtil.getThread(threadId);
+
 	try {
 		curParentMessage = MBMessageServiceUtil.getMessage(parentMessageId);
 
@@ -332,8 +334,6 @@ if (portletTitleBasedNavigation) {
 					String displayStyle = category.getDisplayStyle();
 
 					if (message != null) {
-						thread = MBThreadLocalServiceUtil.getThread(threadId);
-
 						if (thread.isQuestion() || message.isAnswer()) {
 							question = true;
 


### PR DESCRIPTION
The issue was that the the message thread was used before the thread was initialzed.
Moving the point of initialization of the message thread to where the threadID is checked fixes the issue.