### PR TITLE
[TS] LPS-119212 knowledge-base-service: Knowledge Base Article Parent-Child Relationship Lost During Import to New Database

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -183,6 +183,10 @@ public class KBArticleStagedModelDataHandler
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				KBArticle.class);
 
+		Map<Long, Long> kbFolderResourcePrimKeys =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				KBFolder.class);
+
 		long parentResourceClassNameId = _classNameLocalService.getClassNameId(
 			KBFolderConstants.getClassName());
 		long parentResourcePrimKey = KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;
@@ -196,12 +200,31 @@ public class KBArticleStagedModelDataHandler
 				kbArticleResourcePrimKeys, kbArticle.getParentResourcePrimKey(),
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 		}
+		else if (!kbArticleResourcePrimKeys.isEmpty() ||
+				 !kbFolderResourcePrimKeys.isEmpty()) {
+
+			if (kbArticleResourcePrimKeys.containsKey(
+					kbArticle.getParentResourcePrimKey())) {
+
+				parentResourcePrimKey = MapUtil.getLong(
+					kbArticleResourcePrimKeys,
+					kbArticle.getParentResourcePrimKey(),
+					KBFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+				parentResourceClassNameId =
+					kbArticle.getParentResourceClassNameId();
+			}
+
+			if (kbFolderResourcePrimKeys.containsKey(
+					kbArticle.getParentResourcePrimKey())) {
+
+				parentResourcePrimKey = MapUtil.getLong(
+					kbFolderResourcePrimKeys,
+					kbArticle.getParentResourcePrimKey(),
+					KBFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+			}
+		}
 		else if (kbArticle.getParentResourcePrimKey() !=
 					KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-
-			Map<Long, Long> kbFolderResourcePrimKeys =
-				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-					KBFolder.class);
 
 			parentResourcePrimKey = MapUtil.getLong(
 				kbFolderResourcePrimKeys, kbArticle.getParentResourcePrimKey(),


### PR DESCRIPTION
The issue is that the classNameID that is used for determining whether and article is a child or a parent is changed when the database is deleted. There is no way to recreate this ID.
The applied fix uses the primary keys map for both articles and folders to
determine relationships, but only when the classNameID has changed.