### PR TITLE
[TS] LPS-119212 knowledge-base-service: Knowledge Base Article Parent-Child Relationship Lost During Export/Import to New Database

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -129,7 +129,8 @@ public class KBArticleStagedModelDataHandler
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
 			if (kbArticle.getParentResourceClassNameId() ==
-					kbArticle.getClassNameId()) {
+				_classNameLocalService.getClassNameId(
+					KBArticleConstants.getClassName())) {
 
 				KBArticle parentKBArticle =
 					_kbArticleLocalService.getLatestKBArticle(
@@ -187,7 +188,8 @@ public class KBArticleStagedModelDataHandler
 			KBFolderConstants.getClassName());
 		long parentResourcePrimKey = KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 
-		if (kbArticle.getClassNameId() ==
+		if ( _classNameLocalService.getClassNameId(
+			KBArticleConstants.getClassName()) ==
 				kbArticle.getParentResourceClassNameId()) {
 
 			parentResourceClassNameId = _classNameLocalService.getClassNameId(


### PR DESCRIPTION
The issue was the that old classNameId did not matchwith the new classNameId that is stored in the new database.  Instead of calling the kbArticle's classNameID, the _ClassNameIDLocalSerivce will be used to retried the classNameId since it is more inline with the new database. The fix is applied in both the doImport and doExport methods so that any articles that are created have a classNameID of zero in the exported LAR, which is what is expected when an kbArticle is imported.