### PR TITLE
LPS-119212 knowledge-base-service: Knowledge Base Article Parent-Child Relationship Lost During Export/Import to New Database

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -128,8 +128,11 @@ public class KBArticleStagedModelDataHandler
 		if (kbArticle.getParentResourcePrimKey() !=
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
+			long kbArticleClassNameId = _classNameLocalService.getClassNameId(
+				KBArticleConstants.getClassName());
+
 			if (kbArticle.getParentResourceClassNameId() ==
-					kbArticle.getClassNameId()) {
+					kbArticleClassNameId) {
 
 				KBArticle parentKBArticle =
 					_kbArticleLocalService.getLatestKBArticle(
@@ -187,9 +190,10 @@ public class KBArticleStagedModelDataHandler
 			KBFolderConstants.getClassName());
 		long parentResourcePrimKey = KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 
-		if (kbArticle.getClassNameId() ==
-				kbArticle.getParentResourceClassNameId()) {
+		long kbArticleClassNameId = _classNameLocalService.getClassNameId(
+			KBArticleConstants.getClassName());
 
+		if (kbArticleClassNameId == kbArticle.getParentResourceClassNameId()) {
 			parentResourceClassNameId = _classNameLocalService.getClassNameId(
 				KBArticleConstants.getClassName());
 			parentResourcePrimKey = MapUtil.getLong(


### PR DESCRIPTION
Retrieve classNameID using service call instead of kbArticle.getClassName

The issue was that kbAritcle.getClassNameID would retrieve the classNameId from the previous database.  Using the service call will ensure that it will always use the classNameID in the current database.
