### PR TITLE
[TS] LPS-118698 account-admin-web: Add account with name <a> shows as blank

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
@@ -63,7 +63,7 @@ ViewAccountEntriesManagementToolbarDisplayContext viewAccountEntriesManagementTo
 					cssClass="table-cell-expand table-title"
 					href="<%= rowURL %>"
 					name="name"
-					property="name"
+					value="<%= HtmlUtil.escape(accountEntryDisplay.getName()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text


### PR DESCRIPTION
Retrieved account name using value instead of property.

The issue was the account name could have HTML syntax which would show the account name as a blank space.  Using value instead of property allows
the use of HtmlUtil.escape which would the display the account name correctly.