### PR TITLE
[TS] LPS-122070 PortalImpl.getPlidFromPortletId returns 0 for runtime portlets that are nested in web content article templates

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7281,9 +7281,28 @@ public class PortalImpl implements Portal {
 			}
 
 			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-				groupId, privateLayout, LayoutConstants.TYPE_PORTLET);
+				groupId, privateLayout, LayoutConstants.TYPE_CONTENT);
 
-			long plid = getPlidFromPortletId(layouts, portletId, scopeGroupId);
+			long plid = LayoutConstants.DEFAULT_PLID;
+
+			for (Layout layout : layouts) {
+				LayoutTypePortlet layoutTypePortlet =
+					(LayoutTypePortlet)layout.getLayoutType();
+
+				if (getScopeGroupId(layout, portletId) != scopeGroupId) {
+					continue;
+				}
+
+				for (Portlet portlet : layoutTypePortlet.getAllPortlets()) {
+					if (portletId.equals(portlet.getPortletId()) ||
+						(portletId.equals(portlet.getRootPortletId()) &&
+						 !layoutTypePortlet.hasDefaultScopePortletId(
+							 groupId, portletId))) {
+
+						plid = layout.getPlid();
+					}
+				}
+			}
 
 			if (plid != LayoutConstants.DEFAULT_PLID) {
 				return plid;


### PR DESCRIPTION
Hi @ericyanLr,

Please review my fix, and if you approve this change, please forward it to the next approver,
- Please read the related LPP ticket in case you have questions or need more context
- There may be use cases, other than the customer reported, however we only want to focus on this specific use case.
I have tested this fix against LPS-97073 and LPS-74443 to ensure that my change won't mess up anything else.

Thank you for reviewing my fix,
Peter