### PR TITLE
LPS-122484 Add additional system properties to prevent irrelevant logs from appearing when forking a process

### DIFF
--- a/portal-impl/src/com/liferay/portal/configuration/ConfigurationImpl.java
+++ b/portal-impl/src/com/liferay/portal/configuration/ConfigurationImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -47,6 +48,9 @@ import org.apache.commons.configuration.MapConfiguration;
  */
 public class ConfigurationImpl
 	implements com.liferay.portal.kernel.configuration.Configuration {
+
+	public static final String CONFIGURATION_IMPL_QUIET =
+		"configuration.impl.quiet";
 
 	public ConfigurationImpl(
 		ClassLoader classLoader, String name, long companyId, String webId) {
@@ -320,6 +324,12 @@ public class ConfigurationImpl
 	}
 
 	protected void printSources(long companyId, String webId) {
+		if (GetterUtil.getBoolean(
+				System.getProperty(CONFIGURATION_IMPL_QUIET))) {
+
+			return;
+		}
+
 		List<String> sources = _classLoaderAggregateProperties.loadedSources();
 
 		for (int i = sources.size() - 1; i >= 0; i--) {

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -53,7 +53,11 @@ public class PortalClassPathUtil {
 	public static ProcessConfig createProcessConfig(Class<?>... classes) {
 		ProcessConfig.Builder builder = new ProcessConfig.Builder();
 
-		builder.setArguments(Arrays.asList("-Djava.awt.headless=true"));
+		builder.setArguments(
+			Arrays.asList(
+				"-Dconfiguration.impl.quiet=true", "-Djava.awt.headless=true",
+				"-Dserver.detector.quiet=true",
+				"-Dsystem.properties.quiet=true"));
 
 		String classpath = _buildClassPath(classes);
 
@@ -140,7 +144,11 @@ public class PortalClassPathUtil {
 
 		ProcessConfig.Builder builder = new ProcessConfig.Builder();
 
-		builder.setArguments(Arrays.asList("-Djava.awt.headless=true"));
+		builder.setArguments(
+			Arrays.asList(
+				"-Dconfiguration.impl.quiet=true", "-Djava.awt.headless=true",
+				"-Dserver.detector.quiet=true",
+				"-Dsystem.properties.quiet=true"));
 		builder.setBootstrapClassPath(globalClassPath);
 		builder.setReactClassLoader(classLoader);
 		builder.setRuntimeClassPath(portalClassPath);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ServerDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ServerDetector.java
@@ -54,6 +54,8 @@ public class ServerDetector {
 	@Deprecated
 	public static final String RESIN_ID = "resin";
 
+	public static final String SERVER_DETECTOR_QUIET = "server.detector.quiet";
+
 	public static final String SYSTEM_PROPERTY_KEY_SERVER_DETECTOR_SERVER_ID =
 		"server.detector.server.id";
 
@@ -273,7 +275,9 @@ public class ServerDetector {
 	static {
 		_serverType = _detectServerType();
 
-		if (System.getProperty("external-properties") == null) {
+		if (!GetterUtil.getBoolean(System.getProperty(SERVER_DETECTOR_QUIET)) &&
+			(System.getProperty("external-properties") == null)) {
+
 			if (_log.isInfoEnabled()) {
 				_log.info(
 					"Detected server " +


### PR DESCRIPTION
[**LPS-122484**](https://issues.liferay.com/browse/LPS-122484)

**Overview**
Depending on the type of forked process, irrelevant logs may appear in the console. For example, uploading a PDF forks a process to handle PDF preview image generation. However, this fork causes a number of static initializers in the corresponding classes to execute, which then result in the following logs:

```
Loading jar:file:/bundle/tomcat-9.0.33/webapps/ROOT/WEB-INF/lib/portal-impl.jar!/system.properties
Sep 09, 2020 12:40:47 PM com.liferay.portal.kernel.log.Jdk14LogImpl info
INFO: Detected server tomcat
Loading jar:file:/bundle/tomcat-9.0.33/webapps/ROOT/WEB-INF/lib/portal-impl.jar!/portal.properties
```

**Solution**
The proposed solution modifies the forked process to include additional properties in order to suppress the above logs:
| Property | Description |
| --- | --- |
| `configuration.impl.quiet=true` | Suppresses the [portal.properties log](https://github.com/jesseyeh-liferay/liferay-portal/blob/2e76f61a3adbd92badd4fdafd52d49cf1adcc11d/portal-impl/src/com/liferay/portal/configuration/ConfigurationImpl.java#L345) |
| `server.detector.quiet=true` | Suppresses the [server type detection log](https://github.com/jesseyeh-liferay/liferay-portal/blob/2e76f61a3adbd92badd4fdafd52d49cf1adcc11d/portal-kernel/src/com/liferay/portal/kernel/util/ServerDetector.java#L278-L280). This is done via a property instead of a log level because Log4j has not yet been initialized in the static initializers. | 
| `system.properties.quiet` | Suppresses the [system.properties log](https://github.com/jesseyeh-liferay/liferay-portal/blob/2e76f61a3adbd92badd4fdafd52d49cf1adcc11d/portal-kernel/src/com/liferay/portal/kernel/util/SystemProperties.java#L152) |

**Additional Notes**
For a comprehensive overview of previously attempted solutions, please see [PTR-1955](https://issues.liferay.com/browse/PTR-1955).