### PR TITLE
LPS-124315

### DIFF
--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -118,16 +119,31 @@ public class UpdateLanguageActionTest {
 			ThemeDisplay themeDisplay, String expectedRedirect, String url)
 		throws Exception {
 
+		_assertRedirect(themeDisplay, expectedRedirect, url, null);
+	}
+
+	private void _assertRedirect(
+			ThemeDisplay themeDisplay, String expectedRedirect, String url,
+			String virtualHostLanguageId)
+		throws Exception {
+
 		UpdateLanguageAction updateLanguageAction = new UpdateLanguageAction();
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
+
+		if (Validator.isNotNull(virtualHostLanguageId)) {
+			mockHttpServletRequest.setAttribute(
+				WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID, virtualHostLanguageId);
+		}
 
 		HttpSession httpSession = mockHttpServletRequest.getSession();
 
 		httpSession.setAttribute(WebKeys.LOCALE, _targetLocale);
 
 		mockHttpServletRequest.setParameter("redirect", url);
+
+		themeDisplay.setRequest(mockHttpServletRequest);
 
 		String redirect = updateLanguageAction.getRedirect(
 			mockHttpServletRequest, themeDisplay, _targetLocale);
@@ -177,10 +193,19 @@ public class UpdateLanguageActionTest {
 
 		_assertRedirect(themeDisplay, controlPanelURL, controlPanelURL);
 
+		_assertRedirect(
+			themeDisplay, "/" + _targetLocale.getLanguage() + controlPanelURL,
+			controlPanelURL, LocaleUtil.toLanguageId(_sourceLocale));
+
 		if (i18n) {
 			_assertRedirect(
 				themeDisplay, controlPanelURL,
 				"/" + _sourceLocale.getLanguage() + controlPanelURL);
+
+			_assertRedirect(
+				themeDisplay, controlPanelURL,
+				"/" + _sourceLocale.getLanguage() + controlPanelURL,
+				LocaleUtil.toLanguageId(_targetLocale));
 		}
 		else {
 			_assertRedirect(
@@ -237,6 +262,17 @@ public class UpdateLanguageActionTest {
 		_assertRedirect(
 			themeDisplay, targetURL,
 			"/" + _sourceLocale.getLanguage() + sourceURL);
+
+		_assertRedirect(
+			themeDisplay, targetURL,
+			"/" + _sourceLocale.getLanguage() + sourceURL,
+			LocaleUtil.toLanguageId(_targetLocale));
+
+		if (!i18n) {
+			_assertRedirect(
+				themeDisplay, "/" + _targetLocale.getLanguage() + targetURL,
+				sourceURL, LocaleUtil.toLanguageId(_sourceLocale));
+		}
 	}
 
 	private void _testGetRedirectWithPortletFriendlyURL(boolean i18n)
@@ -286,6 +322,17 @@ public class UpdateLanguageActionTest {
 		_assertRedirect(
 			themeDisplay, targetURL,
 			"/" + _sourceLocale.getLanguage() + sourceURL);
+
+		_assertRedirect(
+			themeDisplay, targetURL,
+			"/" + _sourceLocale.getLanguage() + sourceURL,
+			LocaleUtil.toLanguageId(_targetLocale));
+
+		if (!i18n) {
+			_assertRedirect(
+				themeDisplay, "/" + _targetLocale.getLanguage() + targetURL,
+				sourceURL, LocaleUtil.toLanguageId(_sourceLocale));
+		}
 	}
 
 	private static final String _FRIENDLY_URL_SEPARATOR_JOURNAL_ARTICLE = "/w/";

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -226,6 +226,35 @@ public class UpdateLanguageAction implements Action {
 			redirect = redirect + queryString;
 		}
 
+		return adaptRedirectToVirtualHostLanguage(
+			locale, redirect,
+			(String)httpServletRequest.getAttribute(
+				WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID));
+	}
+
+	protected String adaptRedirectToVirtualHostLanguage(
+		Locale locale, String redirect, String virtualHostI18nLanguageId) {
+
+		if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 0) ||
+			Validator.isNull(virtualHostI18nLanguageId) ||
+			!redirect.startsWith(StringPool.SLASH) ||
+			locale.equals(
+				LocaleUtil.fromLanguageId(virtualHostI18nLanguageId))) {
+
+			return redirect;
+		}
+
+		if (redirect.endsWith(StringPool.SLASH)) {
+			redirect = redirect.substring(0, redirect.length() - 1);
+		}
+
+		String localePrefix =
+			StringPool.SLASH + LocaleUtil.toW3cLanguageId(locale.getLanguage());
+
+		if (!redirect.startsWith(localePrefix + StringPool.SLASH)) {
+			return localePrefix + redirect;
+		}
+
 		return redirect;
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8134,10 +8134,24 @@ public class PortalImpl implements Portal {
 
 		Set<String> languageIds = I18nFilter.getLanguageIds();
 
-		if ((languageIds.contains(locale.toString()) &&
-			 (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 1) &&
-			 !locale.equals(LocaleUtil.getDefault())) ||
-			(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
+		HttpServletRequest httpServletRequest = themeDisplay.getRequest();
+
+		String virtualHostI18nLanguageId =
+			(String)httpServletRequest.getAttribute(
+				WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID);
+
+		if (Validator.isNotNull(virtualHostI18nLanguageId)) {
+			if (!locale.equals(
+					LocaleUtil.fromLanguageId(virtualHostI18nLanguageId)) &&
+				(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE != 0)) {
+
+				i18nPath = _buildI18NPath(locale, themeDisplay.getSiteGroup());
+			}
+		}
+		else if ((languageIds.contains(locale.toString()) &&
+				  (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 1) &&
+				  !locale.equals(LocaleUtil.getSiteDefault())) ||
+				 (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
 
 			i18nPath = _buildI18NPath(locale, themeDisplay.getSiteGroup());
 		}

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -483,6 +483,9 @@ public class PortalInstances {
 
 					httpServletRequest.setAttribute(
 						WebKeys.I18N_LANGUAGE_ID, languageId);
+
+					httpServletRequest.setAttribute(
+						WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID, languageId);
 				}
 			}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -784,6 +784,9 @@ public interface WebKeys {
 
 	public static final String USERS_NOTIFIED = "USERS_NOTIFIED";
 
+	public static final String VIRTUAL_HOST_I18N_LANGUAGE_ID =
+		"VIRTUAL_HOST_I18N_LANGUAGE_ID";
+
 	public static final String VIRTUAL_HOST_LAYOUT_SET =
 		"VIRTUAL_HOST_LAYOUT_SET";
 


### PR DESCRIPTION
Hi @ericyanLr 

This fix solves the issue of selecting a different language via Language Selector widget when a virtualhost set for a specific language is in use.

This solution adds a new attribute that is taken into account at the time of generating the new URL from UpdateLanguageAction to set the required target language.

Could you please review it?

Please, let me know if any further clarification is needed.

Thanks in advance

--

Related tickets:
- LPS-124315
- PTR-2116
- PTR-2137