### PR TITLE
[TS] LPS-113402 Avoid request parameter duplication

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/java/com/liferay/layout/type/controller/portlet/internal/layout/type/controller/PortletLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/java/com/liferay/layout/type/controller/portlet/internal/layout/type/controller/PortletLayoutTypeController.java
@@ -106,7 +106,7 @@ public class PortletLayoutTypeController extends BaseLayoutTypeControllerImpl {
 				originalHttpServletRequest =
 					DynamicServletRequestUtil.createDynamicServletRequest(
 						originalHttpServletRequest, portlet,
-						httpServletRequest.getParameterMap(), true);
+						httpServletRequest.getParameterMap(), false);
 			}
 		}
 


### PR DESCRIPTION
Hi @ericyanLr,

the request parameters are duplicated due to the `PortletLayoutTypeController's` implementation of the `LayoutTypeController's` `includeLayoutContent(...)` method. The issue appeared with [LPS-107804](https://issues.liferay.com/browse/LPS-107804) which introduced the merging of request parameters:

```
originalHttpServletRequest =
		DynamicServletRequestUtil.createDynamicServletRequest(
			originalHttpServletRequest, portlet,
			httpServletRequest.getParameterMap(), true);          // --> mergeParameters was 'true'
```
[LPS-113402](https://issues.liferay.com/browse/LPS-113402)

Please review my change.

Thank you,
Nikoletta