### PR TITLE
[TS] LPS-129244

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -551,7 +551,11 @@ public class ServletResponseUtil {
 			isClientAbortException(ioException)) {
 
 			if (_log.isWarnEnabled()) {
-				_log.warn(ioException, ioException);
+				_log.warn(ioException.getMessage());
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(ioException, ioException);
 			}
 		}
 		else {


### PR DESCRIPTION
Hi @ericyanLr,

Currently ClientAbortExceptions or SocketExceptions are being printed with the complete stack trace for a simple warning message (https://issues.liferay.com/browse/LEP-7111), which is tipically related to a abrupt close in the connection by the end user or the socket or any other element in between.

Could you please review it?

Thanks in advance