### PR TITLE
[TECHNICAL SUPPORT] LPS-115406 Advanced search on Audit portlet displays wrong end date

### DIFF
--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
@@ -51,6 +51,7 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 			dayValue="<%= startDateDay %>"
 			monthParam="startDateMonth"
 			monthValue="<%= startDateMonth %>"
+			name="startDate"
 			yearParam="startDateYear"
 			yearValue="<%= startDateYear %>"
 		/>
@@ -62,6 +63,7 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 			hourValue="<%= startDateHour %>"
 			minuteParam="startDateMinute"
 			minuteValue="<%= startDateMinute %>"
+			name="startDateTime"
 		/>
 	</aui:field-wrapper>
 
@@ -71,6 +73,7 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 			dayValue="<%= endDateDay %>"
 			monthParam="endDateMonth"
 			monthValue="<%= endDateMonth %>"
+			name="endDate"
 			yearParam="endDateYear"
 			yearValue="<%= endDateYear %>"
 		/>
@@ -82,6 +85,7 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 			hourValue="<%= endDateHour %>"
 			minuteParam="endDateMinute"
 			minuteValue="<%= endDateMinute %>"
+			name="endDateTime"
 		/>
 	</aui:field-wrapper>
 </liferay-ui:search-toggle>


### PR DESCRIPTION
Hey,

[LPS-115406](https://issues.liferay.com/browse/LPS-115406),

As we discussed in [PTR-1781](https://issues.liferay.com/browse/PTR-1781) I send these changes to master as well, as it resolves the duplicate IDs there as well and eventually resolve the wrong date issue on 7.0

Please review it

Thanks,