### PR TITLE
LPS-131894 Use `getModelAttributes()` to avoid ClassCastException when `object` is a Proxy instance

### DIFF
--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 /**
  * @author Mika Koivisto
@@ -218,15 +217,12 @@ public class RestrictedLiferayObjectWrapper extends LiferayObjectWrapper {
 			if (currentCompanyId != CompanyConstants.SYSTEM) {
 				BaseModel<?> baseModel = (BaseModel<?>)object;
 
-				Map<String, Function<Object, Object>> getterFunctions =
-					(Map<String, Function<Object, Object>>)
-						(Map<String, ?>)baseModel.getAttributeGetterFunctions();
+				Map<String, Object> modelAttributes =
+					baseModel.getModelAttributes();
 
-				Function<Object, Object> function = getterFunctions.get(
-					"companyId");
-
-				if ((function != null) &&
-					(currentCompanyId != (Long)function.apply(object))) {
+				if (!modelAttributes.isEmpty() &&
+					(currentCompanyId != (Long)modelAttributes.get(
+						"companyId"))) {
 
 					throw new TemplateModelException(
 						StringBundler.concat(

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
@@ -220,7 +220,7 @@ public class RestrictedLiferayObjectWrapper extends LiferayObjectWrapper {
 				Map<String, Object> modelAttributes =
 					baseModel.getModelAttributes();
 
-				if (!modelAttributes.isEmpty() &&
+				if (modelAttributes.containsKey("companyId") &&
 					(currentCompanyId != (Long)modelAttributes.get(
 						"companyId"))) {
 

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -47,6 +47,7 @@ import freemarker.template.TemplateModelException;
 import java.io.Serializable;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -412,9 +413,8 @@ public class RestrictedLiferayObjectWrapperTest
 						objectWrapper.wrap(
 							new TestBaseModel(123L) {
 
-								public Map
-									<String, Function<TestBaseModel, Object>>
-										getAttributeGetterFunctions() {
+								public Map<String, Object>
+									getModelAttributes() {
 
 									return Collections.emptyMap();
 								}
@@ -509,9 +509,24 @@ public class RestrictedLiferayObjectWrapperTest
 			return _companyId;
 		}
 
-		@Override
 		public Map<String, Object> getModelAttributes() {
-			return null;
+			Map<String, Object> attributes = new HashMap<>();
+
+			Map<String, Function<TestBaseModel, Object>>
+				attributeGetterFunctions = getAttributeGetterFunctions();
+
+			for (Map.Entry<String, Function<TestBaseModel, Object>> entry :
+					attributeGetterFunctions.entrySet()) {
+
+				String attributeName = entry.getKey();
+				Function<TestBaseModel, Object> attributeGetterFunction =
+					entry.getValue();
+
+				attributes.put(
+					attributeName, attributeGetterFunction.apply(this));
+			}
+
+			return attributes;
 		}
 
 		@Override


### PR DESCRIPTION
Hi @ericyanLr ,

`object` can be a proxy instance and in that case, the `function.apply(object)` throws a `ClassCastException`.
As we discussed, I replaced this approach with `baseModel.getModelAttributes()` to access the `companyId`.

I aslo updated the `RestrictedLiferayObjectWrapperTest` since this new logic requires the `getModelAttributes()` to return the `companyId` through `getAttributeGetterFunctions()`.

[LPS-131894](https://issues.liferay.com/browse/LPS-131894)

Please review my changes.

Thank you,
N