### PR TITLE
[TS] LPS-134601 Use legacy language tags

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -251,17 +251,28 @@ public class I18nServlet extends HttpServlet {
 		_setRequestAttributes(
 			httpServletRequest, httpServletResponse, i18nData);
 
-		Locale locale = LocaleUtil.fromLanguageId(i18nData.getLanguageId());
+		String languageId = i18nData.getLanguageId();
+
+		Locale locale = LocaleUtil.fromLanguageId(languageId);
 
 		httpServletResponse.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 
 		ServletContext servletContext = getServletContext();
 
+		String languageTag = locale.toLanguageTag();
+
+		if (languageId.equals("iw_IL")) {
+			languageTag = "iw-IL";
+		}
+		else if (languageId.equals("in_ID")) {
+			languageTag = "in-ID";
+		}
+
 		httpServletResponse.setHeader(
 			"Location",
 			StringBundler.concat(
-				servletContext.getContextPath(), StringPool.SLASH,
-				locale.toLanguageTag(), i18nData.getPath()));
+				servletContext.getContextPath(), StringPool.SLASH, languageTag,
+				i18nData.getPath()));
 	}
 
 	protected class I18nData {


### PR DESCRIPTION
Hi @ericyanLr ,

Because of https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html

> Legacy language codes
> Locale's constructor has always converted three language codes to their earlier, obsoleted forms: he maps to iw, yi maps to ji, and id maps to in. This continues to be the case, in order to not break backwards compatibility.
> 
> The APIs added in 1.7 map between the old and new language codes, maintaining the old codes internal to Locale (so that getLanguage and toString reflect the old code), but using the new codes in the BCP 47 language tag APIs (so that toLanguageTag reflects the new one). This preserves the equivalence between Locales no matter which code or API is used to construct them.

`locale.toLanguageTag()` redirected iw_IL locales to he-IL

Can you please review?
https://issues.liferay.com/browse/LPS-134601

Thanks,
Balázs