### PR TITLE
[TS] LPS-134550 Cookies do not follow custom context paths

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/order/CommerceOrderHttpHelperImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/order/CommerceOrderHttpHelperImpl.java
@@ -256,7 +256,6 @@ public class CommerceOrderHttpHelperImpl implements CommerceOrderHttpHelper {
 						WebKeys.THEME_DISPLAY);
 
 				cookie.setMaxAge(CookieKeys.MAX_AGE);
-				cookie.setPath(StringPool.SLASH);
 
 				CookieKeys.addCookie(
 					httpServletRequest, themeDisplay.getResponse(), cookie);
@@ -388,7 +387,6 @@ public class CommerceOrderHttpHelperImpl implements CommerceOrderHttpHelper {
 		}
 
 		cookie.setMaxAge(CookieKeys.MAX_AGE);
-		cookie.setPath(StringPool.SLASH);
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/internal/util/CommerceWishListHttpHelperImpl.java
+++ b/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/internal/util/CommerceWishListHttpHelperImpl.java
@@ -108,7 +108,6 @@ public class CommerceWishListHttpHelperImpl
 					cookieName, commerceWishList.getUuid());
 
 				cookie.setMaxAge(CookieKeys.MAX_AGE);
-				cookie.setPath(StringPool.SLASH);
 
 				CookieKeys.addCookie(
 					httpServletRequest, httpServletResponse, cookie);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -359,7 +359,7 @@ AUI.add(
 						'LFR_SESSION_STATE_' + themeDisplay.getUserId();
 
 					instance._cookieOptions = {
-						path: '/',
+						path: themeDisplay.getPathContext() || '/',
 						secure: A.UA.secure,
 					};
 

--- a/modules/apps/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/util/PollsUtil.java
+++ b/modules/apps/polls/polls-web/src/main/java/com/liferay/polls/web/internal/portlet/util/PollsUtil.java
@@ -111,7 +111,6 @@ public class PollsUtil {
 		Cookie cookie = new Cookie(_getCookieName(questionId), StringPool.TRUE);
 
 		cookie.setMaxAge((int)(Time.WEEK / 1000));
-		cookie.setPath(StringPool.SLASH);
 		cookie.setHttpOnly(true);
 
 		CookieKeys.addCookie(httpServletRequest, httpServletResponse, cookie);

--- a/modules/apps/portal-security-sso/portal-security-sso-token-impl/src/main/java/com/liferay/portal/security/sso/token/internal/events/CookieLogoutProcessor.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-token-impl/src/main/java/com/liferay/portal/security/sso/token/internal/events/CookieLogoutProcessor.java
@@ -51,7 +51,6 @@ public class CookieLogoutProcessor implements LogoutProcessor {
 			}
 
 			cookie.setMaxAge(0);
-			cookie.setPath(StringPool.SLASH);
 
 			CookieKeys.addCookie(
 				httpServletRequest, httpServletResponse, cookie);

--- a/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
+++ b/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
@@ -133,14 +133,12 @@ public class RememberMeAutoLogin extends BaseAutoLogin {
 		Cookie cookie = new Cookie(CookieKeys.ID, StringPool.BLANK);
 
 		cookie.setMaxAge(0);
-		cookie.setPath(StringPool.SLASH);
 
 		CookieKeys.addCookie(httpServletRequest, httpServletResponse, cookie);
 
 		cookie = new Cookie(CookieKeys.PASSWORD, StringPool.BLANK);
 
 		cookie.setMaxAge(0);
-		cookie.setPath(StringPool.SLASH);
 
 		CookieKeys.addCookie(httpServletRequest, httpServletResponse, cookie);
 	}

--- a/modules/dxp/apps/commerce-punchout/commerce-punchout-portal-security-auto-login/src/main/java/com/liferay/commerce/punchout/portal/security/auto/login/internal/events/PunchOutLoginPostAction.java
+++ b/modules/dxp/apps/commerce-punchout/commerce-punchout-portal-security-auto-login/src/main/java/com/liferay/commerce/punchout/portal/security/auto/login/internal/events/PunchOutLoginPostAction.java
@@ -166,7 +166,6 @@ public class PunchOutLoginPostAction extends Action {
 		Cookie cookie = new Cookie(cookieName, commerceOrder.getUuid());
 
 		cookie.setMaxAge(-1);
-		cookie.setPath(StringPool.SLASH);
 
 		CookieKeys.addCookie(httpServletRequest, httpServletResponse, cookie);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -395,7 +395,6 @@ public abstract class BaseProfile {
 		}
 
 		companyIdCookie.setMaxAge(0);
-		companyIdCookie.setPath(StringPool.SLASH);
 
 		Cookie idCookie = new Cookie(CookieKeys.ID, StringPool.BLANK);
 
@@ -404,7 +403,6 @@ public abstract class BaseProfile {
 		}
 
 		idCookie.setMaxAge(0);
-		idCookie.setPath(StringPool.SLASH);
 
 		Cookie passwordCookie = new Cookie(
 			CookieKeys.PASSWORD, StringPool.BLANK);
@@ -414,7 +412,6 @@ public abstract class BaseProfile {
 		}
 
 		passwordCookie.setMaxAge(0);
-		passwordCookie.setPath(StringPool.SLASH);
 
 		boolean rememberMe = GetterUtil.getBoolean(
 			CookieKeys.getCookie(httpServletRequest, CookieKeys.REMEMBER_ME));
@@ -427,7 +424,6 @@ public abstract class BaseProfile {
 			}
 
 			loginCookie.setMaxAge(0);
-			loginCookie.setPath(StringPool.SLASH);
 
 			CookieKeys.addCookie(
 				httpServletRequest, httpServletResponse, loginCookie);
@@ -441,7 +437,6 @@ public abstract class BaseProfile {
 		}
 
 		rememberMeCookie.setMaxAge(0);
-		rememberMeCookie.setPath(StringPool.SLASH);
 
 		CookieKeys.addCookie(
 			httpServletRequest, httpServletResponse, companyIdCookie);

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1724,7 +1724,6 @@ public class LanguageImpl implements Language, Serializable {
 		}
 
 		languageIdCookie.setMaxAge(CookieKeys.MAX_AGE);
-		languageIdCookie.setPath(StringPool.SLASH);
 
 		CookieKeys.addCookie(
 			httpServletRequest, httpServletResponse, languageIdCookie);

--- a/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
@@ -178,8 +178,6 @@ public class AuthenticatedSessionManagerImpl
 			companyIdCookie.setDomain(domain);
 		}
 
-		companyIdCookie.setPath(StringPool.SLASH);
-
 		Cookie idCookie = new Cookie(
 			CookieKeys.ID,
 			Encryptor.encrypt(company.getKeyObj(), userIdString));
@@ -187,8 +185,6 @@ public class AuthenticatedSessionManagerImpl
 		if (domain != null) {
 			idCookie.setDomain(domain);
 		}
-
-		idCookie.setPath(StringPool.SLASH);
 
 		int loginMaxAge = PropsValues.COMPANY_SECURITY_AUTO_LOGIN_MAX_AGE;
 
@@ -235,7 +231,6 @@ public class AuthenticatedSessionManagerImpl
 			}
 
 			loginCookie.setMaxAge(loginMaxAge);
-			loginCookie.setPath(StringPool.SLASH);
 
 			CookieKeys.addCookie(
 				httpServletRequest, httpServletResponse, loginCookie, secure);
@@ -249,7 +244,6 @@ public class AuthenticatedSessionManagerImpl
 			}
 
 			passwordCookie.setMaxAge(loginMaxAge);
-			passwordCookie.setPath(StringPool.SLASH);
 
 			CookieKeys.addCookie(
 				httpServletRequest, httpServletResponse, passwordCookie,
@@ -263,7 +257,6 @@ public class AuthenticatedSessionManagerImpl
 			}
 
 			rememberMeCookie.setMaxAge(loginMaxAge);
-			rememberMeCookie.setPath(StringPool.SLASH);
 
 			CookieKeys.addCookie(
 				httpServletRequest, httpServletResponse, rememberMeCookie,
@@ -278,7 +271,6 @@ public class AuthenticatedSessionManagerImpl
 			}
 
 			screenNameCookie.setMaxAge(loginMaxAge);
-			screenNameCookie.setPath(StringPool.SLASH);
 
 			CookieKeys.addCookie(
 				httpServletRequest, httpServletResponse, screenNameCookie,
@@ -295,8 +287,6 @@ public class AuthenticatedSessionManagerImpl
 		Cookie userUUIDCookie = new Cookie(
 			CookieKeys.USER_UUID,
 			Encryptor.encrypt(company.getKeyObj(), userUUID));
-
-		userUUIDCookie.setPath(StringPool.SLASH);
 
 		session.setAttribute(CookieKeys.USER_UUID, userUUID);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -99,13 +99,24 @@ public class CookieKeys {
 		cookie.setValue(encodedValue);
 		cookie.setVersion(0);
 
-		httpServletResponse.addCookie(cookie);
-
 		if (httpServletRequest != null) {
 			Map<String, Cookie> cookieMap = _getCookieMap(httpServletRequest);
 
+			if (cookie.getPath() == null) {
+				String contextPath = httpServletRequest.getContextPath();
+
+				if (Validator.isNotNull(contextPath)) {
+					cookie.setPath(contextPath);
+				}
+				else {
+					cookie.setPath(StringPool.SLASH);
+				}
+			}
+
 			cookieMap.put(StringUtil.toUpperCase(name), cookie);
 		}
+
+		httpServletResponse.addCookie(cookie);
 	}
 
 	public static void addSupportCookie(
@@ -113,8 +124,15 @@ public class CookieKeys {
 		HttpServletResponse httpServletResponse) {
 
 		Cookie cookieSupportCookie = new Cookie(COOKIE_SUPPORT, "true");
+		String contextPath = httpServletRequest.getContextPath();
 
-		cookieSupportCookie.setPath(StringPool.SLASH);
+		if (Validator.isNotNull(contextPath)) {
+			cookieSupportCookie.setPath(contextPath);
+		}
+		else {
+			cookieSupportCookie.setPath(StringPool.SLASH);
+		}
+
 		cookieSupportCookie.setMaxAge(MAX_AGE);
 
 		addCookie(
@@ -132,6 +150,15 @@ public class CookieKeys {
 		}
 
 		Map<String, Cookie> cookieMap = _getCookieMap(httpServletRequest);
+		String contextPath = httpServletRequest.getContextPath();
+		String path;
+
+		if (Validator.isNotNull(contextPath)) {
+			path = contextPath;
+		}
+		else {
+			path = StringPool.SLASH;
+		}
 
 		for (String cookieName : cookieNames) {
 			Cookie cookie = cookieMap.remove(
@@ -143,7 +170,7 @@ public class CookieKeys {
 				}
 
 				cookie.setMaxAge(0);
-				cookie.setPath(StringPool.SLASH);
+				cookie.setPath(path);
 				cookie.setValue(StringPool.BLANK);
 
 				httpServletResponse.addCookie(cookie);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -150,13 +150,10 @@ public class CookieKeys {
 		}
 
 		Map<String, Cookie> cookieMap = _getCookieMap(httpServletRequest);
-		String contextPath = httpServletRequest.getContextPath();
-		String path;
 
-		if (Validator.isNotNull(contextPath)) {
-			path = contextPath;
-		}
-		else {
+		String path = httpServletRequest.getContextPath();
+
+		if (Validator.isNull(path)) {
 			path = StringPool.SLASH;
 		}
 


### PR DESCRIPTION
[LPS-134550](https://issues.liferay.com/browse/LPS-134550)

Hi Eric,

I hope you can review the PR.

In short, cookies are not separated properly if multiple portals are deployed on the same host under different context paths. You are probably familiar with the issue from the related PTR ticket.

Please let me know if you have any questions of concerns.

Thank you,
Istvan
