### PR TITLE
[TS] LPS-137180 AuditEvent captures null values when navigating to Users and Organizations

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-router/src/main/java/com/liferay/portal/security/audit/router/internal/PersistentAuditMessageProcessor.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-router/src/main/java/com/liferay/portal/security/audit/router/internal/PersistentAuditMessageProcessor.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.change.tracking.CTTransactionException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.audit.AuditEventManager;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.router.configuration.PersistentAuditMessageProcessorConfiguration;
@@ -76,7 +77,11 @@ public class PersistentAuditMessageProcessor implements AuditMessageProcessor {
 			return;
 		}
 
-		_auditEventManager.addAuditEvent(auditMessage);
+		String auditMessUsrName = auditMessage.getUserName();
+
+		if (!Validator.isNull(auditMessUsrName)) {
+			_auditEventManager.addAuditEvent(auditMessage);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Hi @ericyanLr,

Please review my fix, and if you approve this change, please forward it to the next approver,
- Please read the related ticket LPP in case you have questions or need more context
- There may be use cases, other than the customer reported, however we only want to focus on this specific use case.

Thank you,
Peter