### PR TITLE
LPS-137532 Add search container results in order to return the correct number of entries per page

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets.jsp
@@ -23,6 +23,8 @@ OrphanPortletsManagementToolbarDisplayContext orphanPortletsManagementToolbarDis
 
 Layout selLayout = orphanPortletsDisplayContext.getSelLayout();
 
+List<Portlet> orphanPortlets = orphanPortletsDisplayContext.getOrphanPortlets();
+
 portletDisplay.setDescription(LanguageUtil.get(request, "orphan-widgets-description"));
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(orphanPortletsDisplayContext.getBackURL());
@@ -66,6 +68,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "orphan-widgets"));
 	<liferay-ui:search-container
 		searchContainer="<%= orphanPortletsDisplayContext.getOrphanPortletsSearchContainer() %>"
 	>
+		<liferay-ui:search-container-results
+			results="<%= orphanPortlets.subList(searchContainer.getStart(), searchContainer.getResultEnd()) %>"
+		/>
+
 		<liferay-ui:search-container-row
 			className="com.liferay.portal.kernel.model.Portlet"
 			escapedModel="<%= true %>"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-137532

The issue here was that the orphan widgets page would not update with the correct number of entries when the number of entries per paged was less than the total number of entries. 
To fix this, I added the search container results so that the correct number of entries are displayed.