### PR TITLE
LPS-137852 Set selPlid to 0 when accessing Public Pages Configuration

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -425,6 +425,8 @@ public class LayoutsAdminDisplayContext {
 			"groupId", themeDisplay.getScopeGroupId()
 		).setParameter(
 			"privateLayout", privatePages
+		).setParameter(
+			"selPlid", LayoutConstants.DEFAULT_PLID
 		).buildString();
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-137852

The issue here is that the Public Pages' look and feel settings change when a page is set to have a specific look and feel. After saving the new theme settings for the page, the Public Pages settings get changed as well.
To fix this issue, I passed the selPlid, with a value of 0, to the URL of the Public Pages Configuration. (Solution based on discussion in [PTR-2616](https://issues.liferay.com/browse/PTR-2616))