### PR TITLE
[TS] LPS-138089

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8513,13 +8513,12 @@ public class PortalImpl implements Portal {
 
 						String serverName = themeDisplay.getServerName();
 
-						if (Validator.isNotNull(serverName)) {
+						if (Validator.isNotNull(serverName) &&
+							!serverName.equals(_LOCALHOST)) {
+
 							virtualHostnames.put(serverName, StringPool.BLANK);
 						}
-
-						if (virtualHostnames.isEmpty() ||
-							virtualHostnames.containsKey(_LOCALHOST)) {
-
+						else {
 							LayoutSet curLayoutSet =
 								LayoutSetLocalServiceUtil.getLayoutSet(
 									themeDisplay.getSiteGroupId(),

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8557,9 +8557,7 @@ public class PortalImpl implements Portal {
 						).build();
 					}
 
-					if (canonicalURL ||
-						!virtualHostnames.containsKey(_LOCALHOST)) {
-
+					if (canonicalURL) {
 						String virtualHostname = getCanonicalDomain(
 							virtualHostnames, portalDomain);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8529,6 +8529,21 @@ public class PortalImpl implements Portal {
 								curLayoutSet.getVirtualHostnames();
 						}
 					}
+					else {
+						try {
+							virtualHostnames.putAll(
+								_getParentVirtualHostnames(
+									layoutSet.getGroupId()));
+						}
+						catch (PortalException portalException) {
+							if (_log.isWarnEnabled()) {
+								_log.warn(
+									"Unable to retrieve parent groups for " +
+										"group: " + layoutSet.getGroupId(),
+									portalException);
+							}
+						}
+					}
 
 					if (virtualHostnames.isEmpty() ||
 						virtualHostnames.containsKey(_LOCALHOST)) {
@@ -8591,6 +8606,29 @@ public class PortalImpl implements Portal {
 		sb.append(group.getFriendlyURL());
 
 		return sb.toString();
+	}
+
+	private TreeMap<String, String> _getParentVirtualHostnames(long groupId)
+		throws PortalException {
+
+		TreeMap<String, String> virtualHostnames = new TreeMap<>();
+
+		LayoutSet layoutSet = null;
+
+		List<Group> parentGroups = GroupLocalServiceUtil.getParentGroups(
+			groupId);
+
+		for (Group parentGroup : parentGroups) {
+			layoutSet = parentGroup.getPublicLayoutSet();
+
+			virtualHostnames.putAll(layoutSet.getVirtualHostnames());
+
+			layoutSet = parentGroup.getPrivateLayoutSet();
+
+			virtualHostnames.putAll(layoutSet.getVirtualHostnames());
+		}
+
+		return virtualHostnames;
 	}
 
 	private String _getPortalURL(


### PR DESCRIPTION
Hey Eric, this is my working solution for LPS-138089.  There are a couple blockers, but they are fairly easy to workaround:
1. There is an issue with the entityCache and the LayoutSetCacheModel.  Basically, the _virtualHostnames variable doesn't get cleared between the parent site and the child site, so the child site will appear to have the same virtual hostnames (not possible) and completely throw-off the results.  To workaround this issue, I just disabled the entity cache.
2. I kept getting a permission error regarding the user (admin) not being able to access the ProductNavigationApplicationsMenuPortlet.  This error prevented the control panel menu from appearing, blocking part of my testing.  To workaround, I just used a breakpoint in my debugger, but you could also add the resourcePermissions.

Aside from the blockers, I'd like your input as to if this solution is viable.  Please let me know if you have any questions.  I can demonstrate the fix if needed, thanks!