### PR TITLE
LPS-137638

### DIFF
--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -143,6 +143,7 @@ private String _filterDefaultSanitizer(String line) {
 			|		<tag name="rp" action="validate" />
 			|		<tag name="rt" action="validate" />
 			|		<tag name="ruby" action="validate" />
+					<tag name="s" action="validate" />
 			|		<tag name="section" action="validate" />
 			|		<tag name="source" action="validate">
 			|			<attribute name="srcset">


### PR DESCRIPTION
**Issue**: CKEditor uses the `<s>` tag to strike through the words on body text but Questions portlet and Message Board execute the Anti Sanitizer method before saving on the database and it was filtering the `<s>` tag. That was happening because the `sanitizer-configuration.xml` did not have the `<s>` tag added on its tag-rules to accept the tag and not filter it. 

**Fix**: The `<s>` tag was added on tag-rules on `sanitizer-configuration.xml` by `build.gradle`. Similar case on [LPS-91238](https://issues.liferay.com/browse/LPS-91238).