### PR TITLE
LPS-139866 Check portlet usage through PortletPreferencesLocalServiceUtil.getPortletPreferencesCount

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
-import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
@@ -77,7 +76,6 @@ import com.liferay.product.navigation.control.menu.constants.ProductNavigationCo
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -478,28 +476,6 @@ public class AddContentPanelDisplayContext {
 				locale -> LanguageUtil.get(locale, "lang.dir")));
 	}
 
-	private Set<String> _getLayoutDecodedPortletNames() {
-		if (_layoutDecodedPortletNames != null) {
-			return _layoutDecodedPortletNames;
-		}
-
-		Set<String> layoutDecodedPortletNames = new HashSet<>();
-
-		LayoutTypePortlet layoutTypePortlet =
-			_themeDisplay.getLayoutTypePortlet();
-
-		for (Portlet layoutPortlet : layoutTypePortlet.getPortlets()) {
-			String decodedPortletName = PortletIdCodec.decodePortletName(
-				layoutPortlet.getPortletId());
-
-			layoutDecodedPortletNames.add(decodedPortletName);
-		}
-
-		_layoutDecodedPortletNames = layoutDecodedPortletNames;
-
-		return _layoutDecodedPortletNames;
-	}
-
 	private String _getPortletCategoryTitle(PortletCategory portletCategory) {
 		for (String portletId :
 				PortletCategoryUtil.getFirstChildPortletIds(portletCategory)) {
@@ -700,7 +676,6 @@ public class AddContentPanelDisplayContext {
 	private Boolean _hasLayoutUpdatePermission;
 	private final HttpServletRequest _httpServletRequest;
 	private String _keywords;
-	private Set<String> _layoutDecodedPortletNames;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.PortletItemLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -61,6 +62,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -675,13 +677,16 @@ public class AddContentPanelDisplayContext {
 			return false;
 		}
 
-		Set<String> layoutDecodedPortletNames = _getLayoutDecodedPortletNames();
+		long count =
+			PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, _themeDisplay.getPlid(),
+				portlet.getPortletId());
 
-		if (layoutDecodedPortletNames.contains(portlet.getPortletId())) {
-			return true;
+		if (count < 1) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Hi @ericyanLr 

could you please review my fix?

**Steps to reproduce:**
_Case 1_

1) Create a layout template and embed a single instance portlet (e.g. Announcements) in one of the columns (or use the attached template).
2) Deploy the template.
3) Create a Widget page and configure the above template for it.
Note #1: The Announcements portlet appears on the page immediately as it is embedded in the template.
4) Try to add the Announcements portlet to the page

_Case2_

1) Create a Web Content Structure with one field item
2) Create a template for the structure with an embedded portelt
<@liferay_portlet["runtime"]
    portletName="com_liferay_announcements_web_portlet_AnnouncementsPortlet"
/>
3) Create a Web Content based on the structure
4) Create a Widget Page
5) Add the Web Content to the page
6) Try to add the Announcements portlet to the page

**Actual behavior:**
The Announcements (single instance) portlet can be added to the page again if it is embedded in the layout template.

**Expected behavior:**
The Announcements (single instance) portlet can not be added to the page again if it is embedded in the layout template.

**Solution**
Instead of checking the layout we can check the portlet preferences

Thanks, Roland

https://issues.liferay.com/browse/LPS-139866
Related ticket: https://issues.liferay.com/browse/LPS-88060

Documentation for Embedding Portlets in a Layout Template on 6.2 with processor.processPortlet: 
https://help.liferay.com/hc/en-us/articles/360018180991-Embedding-Portlets-in-a-Layout-Template

Documentation for Embedding a Portlet by Portlet Name on 7.2 with  @liferay_portlet["runtime"]
https://help.liferay.com/hc/en-us/articles/360028746512-Embedding-a-Portlet-by-Portlet-Name