### PR TITLE
[TECHNICAL SUPPORT] LPS-134601 iw_IL locale prepend won't redirect to iw-IL

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -254,7 +254,7 @@ public class I18nServlet extends HttpServlet {
 		_setRequestAttributes(
 			httpServletRequest, httpServletResponse, i18nData);
 
-		Locale locale = LocaleUtil.fromLanguageId(i18nData.getLanguageId());
+		String languageId = LocaleUtil.toW3cLanguageId(i18nData.getLanguageId());
 
 		httpServletResponse.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 
@@ -264,7 +264,7 @@ public class I18nServlet extends HttpServlet {
 			"Location",
 			StringBundler.concat(
 				servletContext.getContextPath(), StringPool.SLASH,
-				locale.toLanguageTag(), i18nData.getPath()));
+				languageId, i18nData.getPath()));
 	}
 
 	protected class I18nData {


### PR DESCRIPTION
Hey,

Last PR: https://github.com/ericyanLr/liferay-portal/pull/236
Ticket: [LPS-134601](https://issues.liferay.com/browse/LPS-134601)

I red trough your suggestions, and I ended up not depending on the languageTag as we are not supporting the newest languageTags (he,id,yi)
Instead I modified sendRedirect to create a W3cLanguageId and use that in our redirect url. This resolves the issue without hardcoding the specific use cases for this 3 language and we can switch back to using languageTags once we are prepared to handle them.

Please review my changes.

Thanks