### PR TITLE
LPS-145833 Set ddmFormFieldValue string to null when string is empty and ddmFormField is repeatable

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/DDMFormValuesToPropertiesConverter.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/DDMFormValuesToPropertiesConverter.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.settings.LocationVariableProtocol;
 import com.liferay.portal.kernel.settings.LocationVariableResolver;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
@@ -176,10 +177,17 @@ public class DDMFormValuesToPropertiesConverter {
 		}
 
 		if (valueString.equals(StringPool.BLANK)) {
-			String dataType = getDDMFormFieldDataType(
-				ddmFormFieldValue.getName());
+			DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
 
-			valueString = _getDataTypeDefaultValue(dataType);
+			if (ddmFormField.isRepeatable()) {
+				valueString = null;
+			}
+			else {
+				String dataType = getDDMFormFieldDataType(
+					ddmFormFieldValue.getName());
+
+				valueString = _getDataTypeDefaultValue(dataType);
+			}
 		}
 
 		return valueString;
@@ -253,7 +261,12 @@ public class DDMFormValuesToPropertiesConverter {
 		Vector<Serializable> values = new Vector<>();
 
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
-			values.add(_toSimpleValue(ddmFormFieldValue));
+			Serializable simpleDDMFormFieldValue = _toSimpleValue(
+				ddmFormFieldValue);
+
+			if (Validator.isNotNull(simpleDDMFormFieldValue)) {
+				values.add(simpleDDMFormFieldValue);
+			}
 		}
 
 		return values;

--- a/modules/apps/configuration-admin/configuration-admin-web/src/test/java/com/liferay/configuration/admin/web/internal/util/DDMFormValuesToPropertiesConverterTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/test/java/com/liferay/configuration/admin/web/internal/util/DDMFormValuesToPropertiesConverterTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Locale;
 import java.util.Vector;
@@ -121,6 +122,118 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		Assert.assertTrue(booleanValues[0]);
 		Assert.assertFalse(booleanValues[1]);
 		Assert.assertTrue(booleanValues[2]);
+	}
+
+	@Test
+	public void testEmptyStringValue() {
+		DDMForm ddmForm = new DDMForm();
+
+		ddmForm.addAvailableLocale(_enLocale);
+		ddmForm.setDefaultLocale(_enLocale);
+
+		DDMFormField booleanDDMFormField = DDMFormTestUtil.createDDMFormField(
+			"String", "String", DDMFormFieldType.TEXT, "string", false, true,
+			false);
+
+		ddmForm.addDDMFormField(booleanDDMFormField);
+
+		DDMFormValues ddmFormValues = new DDMFormValues(ddmForm);
+
+		ddmFormValues.addAvailableLocale(_enLocale);
+		ddmFormValues.setDefaultLocale(_enLocale);
+
+		ddmFormValues.addDDMFormFieldValue(
+			createDDMFormFieldValue("String", "", _enLocale));
+
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
+
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
+
+		Configuration configuration = mock(Configuration.class);
+
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
+
+		whenGetCardinality(extendedAttributeDefinition, 1);
+		whenGetID(extendedAttributeDefinition, "String");
+
+		ConfigurationModel configurationModel = new ConfigurationModel(
+			null, null, configuration, extendedObjectClassDefinition, false);
+
+		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
+			new DDMFormValuesToPropertiesConverter(
+				configurationModel, ddmFormValues, _jsonFactory, _enLocale);
+
+		Dictionary<String, Object> properties =
+			ddmFormValuesToPropertiesConverter.getProperties();
+
+		Object value = properties.get("String");
+
+		String[] stringValues = (String[])value;
+
+		Assert.assertEquals(
+			Arrays.toString(stringValues), 0, stringValues.length);
+	}
+
+	@Test
+	public void testEmptyValueArrayStringValues() {
+		DDMForm ddmForm = new DDMForm();
+
+		ddmForm.addAvailableLocale(_enLocale);
+		ddmForm.setDefaultLocale(_enLocale);
+
+		DDMFormField booleanDDMFormField = DDMFormTestUtil.createDDMFormField(
+			"String", "String", DDMFormFieldType.TEXT, "string", false, true,
+			false);
+
+		ddmForm.addDDMFormField(booleanDDMFormField);
+
+		DDMFormValues ddmFormValues = new DDMFormValues(ddmForm);
+
+		ddmFormValues.addAvailableLocale(_enLocale);
+		ddmFormValues.setDefaultLocale(_enLocale);
+
+		ddmFormValues.addDDMFormFieldValue(
+			createDDMFormFieldValue("String", "A", _enLocale));
+		ddmFormValues.addDDMFormFieldValue(
+			createDDMFormFieldValue("String", "", _enLocale));
+		ddmFormValues.addDDMFormFieldValue(
+			createDDMFormFieldValue("String", "B", _enLocale));
+
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
+
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
+
+		Configuration configuration = mock(Configuration.class);
+
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
+
+		whenGetCardinality(extendedAttributeDefinition, 3);
+		whenGetID(extendedAttributeDefinition, "String");
+
+		ConfigurationModel configurationModel = new ConfigurationModel(
+			null, null, configuration, extendedObjectClassDefinition, false);
+
+		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
+			new DDMFormValuesToPropertiesConverter(
+				configurationModel, ddmFormValues, _jsonFactory, _enLocale);
+
+		Dictionary<String, Object> properties =
+			ddmFormValuesToPropertiesConverter.getProperties();
+
+		Object value = properties.get("String");
+
+		String[] stringValues = (String[])value;
+
+		Assert.assertEquals(
+			Arrays.toString(stringValues), 2, stringValues.length);
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145833

The issue here is that the system configurations for Redirect URL will save the allowed domains list as a list of size 1 with an empty string instead of a list of size 0. 
This was fixed by adding a condition to save the field value as null instead of the default value ("") when the field is repeatable.