### PR TITLE
Lps 150838

### DIFF
--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
@@ -440,11 +440,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>SALE_PRICE_FIELD</td>
-	<td>//div/input[contains(@id,'promoPrice')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>ACCORDION</td>
 	<td>//fieldset//div/a[contains(@aria-expanded,'true')]</td>
 	<td></td>

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -604,9 +604,13 @@ public class PortletImportControllerImpl implements PortletImportController {
 						}
 					}
 
-					exportImportPortletPreferencesProcessor.
-						processImportPortletPreferences(
-							portletDataContext, jxPortletPreferences);
+					if (portletDataContext.getGroupId() ==
+							portletDataContext.getScopeGroupId()) {
+
+						exportImportPortletPreferencesProcessor.
+							processImportPortletPreferences(
+								portletDataContext, jxPortletPreferences);
+					}
 				}
 			}
 			finally {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -252,7 +252,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	public String getSearchInputName() {
 		if (_searchInputName == null) {
 			if (_managementToolbarDisplayContext != null) {
-				_managementToolbarDisplayContext.getSearchInputName();
+				return _managementToolbarDisplayContext.getSearchInputName();
 			}
 
 			return ManagementToolbarDefaults.getSearchInputName();
@@ -332,7 +332,8 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	public Boolean isSearchInputAutoFocus() {
 		if (_searchInputAutoFocus == null) {
 			if (_managementToolbarDisplayContext != null) {
-				_managementToolbarDisplayContext.isSearchInputAutoFocus();
+				return _managementToolbarDisplayContext.
+					isSearchInputAutoFocus();
 			}
 
 			return ManagementToolbarDefaults.isSearchInputAutoFocus();

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/macros/RaylifePaymentMethod.macro
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/macros/RaylifePaymentMethod.macro
@@ -1,49 +1,5 @@
 definition {
 
-	macro configurationPaypal {
-		ApplicationsMenu.gotoPortlet(
-			category = "Store Management",
-			panel = "Commerce",
-			portlet = "Channels");
-
-		CommerceNavigator.gotoEntry(entryName = "Raylife Channel");
-
-		CommerceChannels.activatePaymentMethod(paymentMethod = "PayPal");
-
-		Refresh();
-
-		CommerceEntry.clickTableEntryEditButton(
-			entryName = "PayPal",
-			table = "Payment Methods");
-
-		SelectFrame.selectFrameNoLoading(locator1 = "CommerceEntry#IFRAME_SIDE_PANEL");
-
-		Click(
-			locator1 = "CommerceEntry#PAYMENT_METHODS_SIDE_PANEL_NAV_ITEMS",
-			navItem = "Configuration");
-
-		Type(
-			key_text = "Client ID",
-			locator1 = "TextInput#ANY",
-			value1 = "AbYFv5Emsgk85LbhRSu3Hp4ur-9YJdTBz27bWRYD0EnrGxN4BZxWD77upJ8tTQ2W2dbJ-Ln0CdVFaPXj");
-
-		Type(
-			key_text = "Client Secret",
-			locator1 = "TextInput#ANY",
-			value1 = "EMiMaIJKB121Z_bYFDOxLPe0kkIQMkhUuKf_v9uOUFQ2tqyauoxdwwwb8ZNAQlYM_ns7sBGIP-GDgJKI");
-
-		Select(
-			key_fieldLabel = "Mode",
-			locator1 = "Select#GENERIC_SELECT_FIELD",
-			value1 = "Sandbox");
-
-		Button.clickSave();
-
-		Click(locator1 = "Icon#CLOSE");
-
-		Refresh();
-	}
-
 	macro enablePayPalPayment {
 		ApplicationsMenu.gotoPortlet(
 			category = "Store Management",
@@ -61,101 +17,12 @@ definition {
 		Refresh();
 	}
 
-	macro enablePricingPaypal {
-		ApplicationsMenu.gotoPortlet(
-			category = "Product Management",
-			panel = "Commerce",
-			portlet = "Products");
-
-		CommerceNavigator.gotoEntry(entryName = "Business Owners Policy");
-
-		CommerceEntry.gotoMenuTab(menuTab = "SKUs");
-
-		CommerceNavigator.gotoEntry(entryName = "PAY IN FULL");
-
-		WaitForElementPresent(locator1 = "CommerceEntry#IFRAME_SIDE_PANEL");
-
-		SelectFrame.selectFrameNoLoading(locator1 = "CommerceEntry#IFRAME_SIDE_PANEL");
-
-		Type(
-			locator1 = "CommerceEntry#PRICE_FIELD",
-			value1 = "1.00");
-
-		Type(
-			locator1 = "CommerceEntry#SALE_PRICE_FIELD",
-			value1 = "1.00");
-
-		Type(
-			locator1 = "CommerceEntry#COST_FIELD",
-			value1 = "1.00");
-
-		Button.clickPublish();
-
-		Alert.viewSuccessMessage();
-
-		Click(locator1 = "Icon#CLOSE");
-
-		IFrame.selectTopFrame();
-
-		CommerceNavigator.gotoEntry(entryName = "INSTALLMENT");
-
-		WaitForElementPresent(locator1 = "CommerceEntry#IFRAME_SIDE_PANEL");
-
-		SelectFrame.selectFrameNoLoading(locator1 = "CommerceEntry#IFRAME_SIDE_PANEL");
-
-		Type(
-			locator1 = "CommerceEntry#PRICE_FIELD",
-			value1 = "1.00");
-
-		Type(
-			locator1 = "CommerceEntry#SALE_PRICE_FIELD",
-			value1 = "1.00");
-
-		Type(
-			locator1 = "CommerceEntry#COST_FIELD",
-			value1 = "1.00");
-
-		Button.clickPublish();
-
-		Alert.viewSuccessMessage();
-
-		Click(locator1 = "Icon#CLOSE");
-
-		IFrame.selectTopFrame();
-
-		Button.clickPublish();
-	}
-
 	macro payPalFlow {
 		Click(locator1 = "RaylifePaymentMethod#PAYMENT_METHOD_PAYPAL");
 
 		Click(locator1 = "RaylifePaymentMethod#TERMS_CONDITIONS_CHECKBOX");
 
 		Click(locator1 = "RaylifePaymentMethod#PAY_NOW");
-	}
-
-	macro paypalPaymentFlow {
-		Type(
-			locator1 = "RaylifePaymentMethod#FIELD_EMAIL_PAYPAL",
-			value1 = "qa-paypal-buyer@liferay.com");
-
-		Click(locator1 = "RaylifePaymentMethod#BUTTON_NEXT_PAYPAL");
-
-		Type(
-			locator1 = "RaylifePaymentMethod#FIELD_PASSWORD_PAYPAL",
-			value1 = "Liferay123");
-
-		Click(locator1 = "RaylifePaymentMethod#BUTTON_LOGIN_PAYPAL");
-
-		AssertElementPresent(
-			locator1 = "RaylifePaymentMethod#TEST_BUYER_PAYPAL",
-			text = "test buyer");
-
-		AssertElementPresent(
-			locator1 = "RaylifePaymentMethod#VALUE_QUOTATION_PAYPAL",
-			value = "$683.05");
-
-		Click(locator1 = "RaylifePaymentMethod#BUTTON_CONTINUE_PAYPAL");
 	}
 
 }

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/paths/RaylifePaymentMethod.path
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/paths/RaylifePaymentMethod.path
@@ -75,36 +75,6 @@
 	<td>//input[contains(@id, 'email')]</td>
 	<td></td>
 </tr>
-<tr>
-	<td>FIELD_PASSWORD_PAYPAL</td>
-	<td>//input[contains(@id, 'password')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>BUTTON_NEXT_PAYPAL</td>
-	<td>//button[contains(@class, 'actionContinue')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>BUTTON_LOGIN_PAYPAL</td>
-	<td>//button[contains(@id, 'btnLogin')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>TEST_BUYER_PAYPAL</td>
-	<td>//p[text()='${text}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>VALUE_QUOTATION_PAYPAL</td>
-	<td>//span[text()='${value}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>BUTTON_CONTINUE_PAYPAL</td>
-	<td>//button[contains(@id, 'payment-submit-btn')]</td>
-	<td></td>
-</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePaymentMethod.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePaymentMethod.testcase
@@ -29,7 +29,7 @@ definition {
 	@description = "LPS-144582 - Check if I am redirected to the payment confirmation page, after selected payment by PayPal"
 	@priority = "5"
 	test CanViewConfirmSuccessfulPayment {
-		RaylifePaymentMethod.configurationPaypal();
+		RaylifePaymentMethod.enablePayPalPayment();
 
 		ApplicationsMenu.gotoSite(key_site = "Raylife");
 
@@ -55,7 +55,7 @@ definition {
 
 		Click(locator1 = "RaylifePaymentMethod#PAY_NOW");
 
-		AssertElementPresent(locator1 = "RaylifePaymentMethod#FIELD_EMAIL_PAYPAL");
+		AssertElementPresent(locator1 = "RaylifePaymentMethod#CONGRATS");
 	}
 
 	@description = "LPS-144583 - Check if the payment method is not selected by default"

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePolicyDeclaration.testcase
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/tests/RaylifePolicyDeclaration.testcase
@@ -29,9 +29,7 @@ definition {
 	@description = "LPS-144591 - Verify that the Policy Declaration Page is reached by the get a quote form"
 	@priority = "5"
 	test CanReachPolicyDeclarationPageByTheForm {
-		RaylifePaymentMethod.configurationPaypal();
-
-		RaylifePaymentMethod.enablePricingPaypal();
+		RaylifePaymentMethod.enablePayPalPayment();
 
 		ApplicationsMenu.gotoSite(key_site = "Raylife");
 
@@ -52,8 +50,6 @@ definition {
 		Click(locator1 = "RaylifeUploadDocuments#BUTTON_CONFIRM_UPLOADS");
 
 		RaylifePaymentMethod.payPalFlow();
-
-		RaylifePaymentMethod.paypalPaymentFlow();
 
 		AssertElementPresent(locator1 = "RaylifePolicyDeclaration#CONGRATS_PAGE_POLICY_DECLARATION");
 	}

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/error_remote_export_exception.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/error_remote_export_exception.jspf
@@ -56,6 +56,17 @@
 
 	<c:if test="<%= ree.getType() == RemoteExportException.NO_GROUP %>">
 		<liferay-ui:message arguments='<%= "<em>" + ree.getGroupId() + "</em>" %>' key="no-site-exists-on-the-remote-server-with-site-id-x" translateArguments="<%= false %>" />
+
+		<c:if test="<%= liveGroup.isStaged() && liveGroup.isStagedRemotely() %>">
+			<c:choose>
+				<c:when test="<%= layout.isTypeControlPanel() %>">
+					<liferay-ui:message arguments='<%= "javascript:" + liferayPortletResponse.getNamespace() + "saveGroup(true);" %>' key="you-can-also-forcibly-disable-remote-staging" />
+				</c:when>
+				<c:otherwise>
+					<liferay-ui:message key="if-everything-is-configured-correctly,-but-you-still-encounter-this-error,-the-administrator-has-the-option-to-forcibly-disable-remote-staging" />
+				</c:otherwise>
+			</c:choose>
+		</c:if>
 	</c:if>
 
 	<c:if test="<%= ree.getType() == RemoteExportException.NO_PERMISSIONS %>">

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -1023,7 +1023,7 @@ public class SXPBlueprintSearchResultTest {
 				).put(
 					"start_date",
 					DateUtil.getDate(
-						new Date(System.currentTimeMillis() - 300),
+						new Date(System.currentTimeMillis() - 1000),
 						"yyyyMMddHHmmss", LocaleUtil.US)
 				).build()
 			},

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -517,7 +517,7 @@ public class SXPBlueprintSearchResultTest {
 		_addJournalArticleSleep = 3;
 
 		_setUpJournalArticles(
-			new String[] {"", ""},
+			new String[] {"Created", ""},
 			new String[] {"First Created", "Second Created"});
 
 		_updateElementInstancesJSON(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -446,7 +446,7 @@ public class SXPBlueprintSearchResultTest {
 		_addGroupAAndGroupB();
 
 		_setUpJournalArticles(
-			new String[] {"", ""},
+			new String[] {"Site", ""},
 			new String[] {"Site Default Group", "Site Group B"});
 
 		User userSiteB = UserTestUtil.addUser(_groupB.getGroupId());

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -771,7 +771,7 @@ public class SXPBlueprintSearchResultTest {
 				Arrays.toString(suppressed));
 		}
 
-		_assertSearch(
+		_assertSearchIgnoreRelevance(
 			"[liferay]",
 			searchRequestBuilder -> searchRequestBuilder.withSearchContext(
 				searchContext -> searchContext.setAttribute(
@@ -828,7 +828,7 @@ public class SXPBlueprintSearchResultTest {
 			},
 			new String[] {"Hide by Exact Term Match"});
 
-		_assertSearch("[Out of the folder]");
+		_assertSearchIgnoreRelevance("[Out of the folder]");
 
 		_updateElementInstancesJSON(null, null);
 
@@ -937,7 +937,7 @@ public class SXPBlueprintSearchResultTest {
 
 		_keywords = "cafe";
 
-		_assertSearch("[Cloud Cafe]");
+		_assertSearchIgnoreRelevance("[Cloud Cafe]");
 
 		_updateElementInstancesJSON(
 			new Object[] {
@@ -972,7 +972,7 @@ public class SXPBlueprintSearchResultTest {
 				"Text Match Over Multiple Fields", "Hide Hidden Contents"
 			});
 
-		_assertSearch("[Cafe Rio, Starbucks Cafe]");
+		_assertSearchIgnoreRelevance("[Cafe Rio, Starbucks Cafe]");
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -792,13 +792,6 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 		try {
 			GroupServiceHttp.disableStaging(httpPrincipal, remoteGroupId);
 		}
-		catch (NoSuchGroupException noSuchGroupException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Remote live group was already deleted",
-					noSuchGroupException);
-			}
-		}
 		catch (PrincipalException principalException) {
 
 			// LPS-52675
@@ -840,6 +833,24 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 						RemoteExportException.BAD_CONNECTION);
 
 				remoteExportException.setURL(remoteURL);
+
+				throw remoteExportException;
+			}
+
+			if (_log.isWarnEnabled()) {
+				_log.warn("Forcibly disable remote staging");
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			if (!forceDisable) {
+				RemoteExportException remoteExportException =
+					new RemoteExportException(RemoteExportException.NO_GROUP);
+
+				remoteExportException.setGroupId(remoteGroupId);
 
 				throw remoteExportException;
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-150838

The issue here is that the Global portlet permissions were being overwritten when importing site preferences and a widget was scoped to the Global site. 
It was occurring due to the global site being passed [here](https://github.com/liferay/liferay-portal-ee/blob/b61b73224e3dbf621004761d7480b9a1184dd02d/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java#L1488) as the new resource and being overwritten by the imported site's settings

To fix the issue, I added an if statement to see whether the portlet being updated belongs to the new site. To do that, I check whether the current site's groupId is the same as the portlet's scopeGroupId