### PR TITLE
LPS-154165 Add Comment buttons formatted the same as other buttons

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
@@ -134,8 +134,8 @@ export default withRouter(
 												answer.status !== 'pending' &&
 												!comments.length && (
 													<ClayButton
-														className="btn-sm c-px-2 c-py-1 text-reset text-secondary"
-														displayType="secondary"
+														className="text-reset"
+														displayType="unstyled"
 														onClick={() =>
 															setShowNewComment(
 																true
@@ -292,8 +292,8 @@ export default withRouter(
 							{answer.actions['reply-to-message'] &&
 								answer.status !== 'pending' && (
 									<ClayButton
-										className="btn-sm c-px-2 c-py-1 text-reset text-secondary"
-										displayType="secondary"
+										className="text-reset"
+										displayType="unstyled"
 										onClick={() => setShowNewComment(true)}
 									>
 										{Liferay.Language.get('add-comment')}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154165
Due to recent changes, in a Questions widget, the button "Reply" was changed to "Add Comment", and also had a formatting update, giving it a different style than the other options. The LPS requested that all buttons have the same format like they did before the changes. This update changes the format back to the original format for both "Add Comment" buttons (the button initially seen, as well as the button that appears after a comment has been posted).

Example:
Before all changes:
![image](https://user-images.githubusercontent.com/106186314/176460294-6ba2cab7-708d-4a80-93b4-e10ab6e87631.png)

After the recent updates:
![image](https://user-images.githubusercontent.com/106186314/176460333-5692780c-5552-43e5-96db-aed2806fc561.png)

After my formatting changes :
![image](https://user-images.githubusercontent.com/106186314/176460365-c3c1ba23-a5e2-47ec-bd77-c067ca68e5a1.png)
(second button)
![image](https://user-images.githubusercontent.com/106186314/176461202-25cf28b8-eccd-4010-ade5-fa2801c1f81a.png)
