### PR TITLE
Lps 154801

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1395,6 +1395,11 @@ public class PortalImpl implements Portal {
 				parametersURL = completeURL.substring(pos);
 			}
 		}
+		else {
+			groupFriendlyURL = getGroupFriendlyURL(
+				layout.getLayoutSet(), themeDisplay, true,
+				layout.isTypeControlPanel());
+		}
 
 		if (layout == null) {
 			layout = themeDisplay.getLayout();
@@ -1428,10 +1433,6 @@ public class PortalImpl implements Portal {
 
 			canonicalLayoutFriendlyURL = defaultLayoutFriendlyURL;
 		}
-
-		groupFriendlyURL = getGroupFriendlyURL(
-			layout.getLayoutSet(), themeDisplay, true,
-			layout.isTypeControlPanel());
 
 		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
 			String groupFriendlyURLDomain = HttpComponentsUtil.getDomain(


### PR DESCRIPTION
Hi Eric, can you help review this PR. There is a slack [conversation](https://liferay.slack.com/archives/C026NQPV6TV/p1653601971389999) associated with this issue and it said that it was fixed with this [PR](https://github.com/liferay-lima/liferay-portal/pull/3115) but even with those changes the issue is still reproducible. 
There's this [other slack thread](https://liferay.slack.com/archives/CLD39UKM5/p1654097745538859?thread_ts=1653655992.115419&cid=CLD39UKM5) linked where the product team say that this issue can't be fixed but then submit the linked PR as a fix.
I couldn't find anything that verifies whether this issue was actually addressed or not. 
I helped Jake with debugging and we found that right before the method `getGroupFriendlyURL()` is called, `groupFriendlyURL` has "resources" in the URL. But then it gets overwritten with `getGroupFriendlyURL()` 
We tried moving this method to an else statement so that it only gets called when `completeURL` is null and it seems to fix the issue.
Can you help determine whether this is the correct approach to this issue or if this issue should even be fixed? 

Notes from @jakesliwka

> https://issues.liferay.com/browse/LPS-154801
> 
> When viewing the canonical URL of a page with a custom link containing a URL separator, such as "/l/", the URL would be split up and displayed incorrectly. This issue was caused by the getCanonicalURL() method that was returning incorrect URLS.
> The method returns groupFriendlyURL, which initially holds the correct value of the URL contents up to the URL separator, but upon reviewing where it is changed, it seemed that every time it went through being set to
> 
> getGroupFriendlyURL(layout.getLayoutSet(), themeDisplay, true, layout.isTypeControlPanel());
> 
> it was returning as "localhost:8000". It would then combine itself with parametersURL, which contained the last half of the URL starting from the URL separator. So, the URL would return incorrectly, displaying everything in the URL from the URL separator forward.
> 
> For example:
> /resources/l/digital-strategy
> would return as
> /l/digital-strategy
> 
> The change was created with the mindset that, if the URL is null, a groupFriendlyURL will be generated as before. This ensures that this code is only used when needed. If the URL is not null, then the groupFriendlyURL is initialized as normal and not overwritten.