### PR TITLE
Lps 157163

### DIFF
--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
@@ -101,6 +101,8 @@ public class FriendlyURLServlet extends HttpServlet {
 					deleteFriendlyURLLocalizationEntry(
 						_getEntryId(httpServletRequest),
 						_getLanguageId(httpServletRequest));
+				_friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+					_getEntryId(httpServletRequest));
 
 				_writeJSON(httpServletResponse, JSONUtil.put("success", true));
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-157163

The issue here is that an orphan FriendlyURLEntry gets left in the database when a layout's old friendly url is deleted.