### PR TITLE
LPS-169433 Use Validator to take into account empty strings

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -372,7 +372,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 				Serializable value = field.getValue(locale);
 
-				if (value == null) {
+				if (Validator.isNull(value)) {
 					continue;
 				}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-169433

The issue here is that the DDMIndexer is adding empty string values to the indexed content.
To fix the issue, I changed the check to use the Validator to check against both null and empty strings.