### PR TITLE
LPS-172099 Set the CompanyThreadLocal to the current company to retrieve the CTCollection from the correct database

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/messaging/ScheduledPublishMessageListener.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/messaging/ScheduledPublishMessageListener.java
@@ -18,12 +18,14 @@ import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTProcessLocalService;
 import com.liferay.change.tracking.web.internal.constants.CTDestinationNames;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -67,14 +69,24 @@ public class ScheduledPublishMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
-			message.getLong("ctCollectionId"));
+		CTCollection ctCollection = null;
 
-		if ((ctCollection != null) &&
-			(ctCollection.getStatus() == WorkflowConstants.STATUS_SCHEDULED)) {
+		long companyId = message.getLong("companyId");
 
-			_ctProcessLocalService.addCTProcess(
-				message.getLong("userId"), ctCollection.getCtCollectionId());
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+
+			ctCollection = _ctCollectionLocalService.fetchCTCollection(
+				message.getLong("ctCollectionId"));
+
+			if ((ctCollection != null) &&
+				(ctCollection.getStatus() ==
+					WorkflowConstants.STATUS_SCHEDULED)) {
+
+				_ctProcessLocalService.addCTProcess(
+					message.getLong("userId"),
+					ctCollection.getCtCollectionId());
+			}
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-172099

The issue here is that the CTCollection is not retrieved when a publication is scheduled to publish and there are multiple databases. Therefore, the CTCollection's status does not get updated and the publication is not published.

To fix this issue, I set the CompanyThreadLocal before retrieving the CTCollection so that the query is run on the correct database.