### PR TITLE
LPS-172254 Check whether the layout is an Asset Display Page

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
@@ -288,11 +288,18 @@ public class BreadcrumbUtil {
 
 		int layoutsPageCount = 0;
 
-		if (layoutSet.isPrivateLayout()) {
-			layoutsPageCount = group.getPrivateLayoutsPageCount();
-		}
-		else {
+		Layout layout = themeDisplay.getLayout();
+
+		String type = layout.getType();
+
+		boolean assetDisplay = type.equals(LayoutConstants.TYPE_ASSET_DISPLAY);
+
+		if (!layoutSet.isPrivateLayout()) {
 			layoutsPageCount = group.getPublicLayoutsPageCount();
+		}
+
+		if ((layoutsPageCount == 0) && assetDisplay) {
+			layoutsPageCount = group.getPrivateLayoutsPageCount();
 		}
 
 		if ((layoutsPageCount > 0) && !_isGuestGroup(group)) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3165,9 +3165,17 @@ public class PortalImpl implements Portal {
 
 		Group group = GroupLocalServiceUtil.getGroup(layoutSet.getGroupId());
 
+		Layout layout = themeDisplay.getLayout();
+
+		String type = layout.getType();
+
+		boolean assetDisplay = type.equals(LayoutConstants.TYPE_ASSET_DISPLAY);
+
 		String friendlyURL = null;
 
-		if (layoutSet.isPrivateLayout()) {
+		if (layoutSet.isPrivateLayout() ||
+			(assetDisplay && !group.hasPublicLayouts())) {
+
 			if (group.isUser()) {
 				friendlyURL = _PRIVATE_USER_SERVLET_MAPPING;
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-172254

The issue here that the breadcrumbs widget in a display page template does not show the current site when the site only has private pages. This is due to the display page template being a "public layout" and therefore the layoutsPageCount will be the number of public pages available in the site. However, in this situation, the site does not have any public pages.
After fixing the logic for `_addGroupsBreadcrumbEntries`, the other issue that occurred is the rendering of the friendly URL. The incorrect servlet mapping is added to the URL for the same reason above. 

To fix the issue, I adjusted the logic for checking for public vs private layouts by taking into account whether the layout is an asset display.