### PR TITLE
[TS] LPS-183708 - missing language keys should default to language.properties rather than the default locale

### DIFF
--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -140,7 +140,7 @@ public class LanguageResourcesExtender
 		}
 
 		Enumeration<URL> enumeration = bundle.findEntries(
-			path, name.concat("_*.properties"), false);
+			path, name.concat("*.properties"), false);
 
 		if (enumeration == null) {
 			return;
@@ -151,9 +151,14 @@ public class LanguageResourcesExtender
 
 			String urlPath = url.getPath();
 
-			String languageId = urlPath.substring(
-				path.length() + name.length() + 2,
-				urlPath.length() - ".properties".length());
+			String languageId = "";
+
+			int start = path.length() + name.length() + 2;
+			int end = urlPath.length() - ".properties".length();
+
+			if (start < end) {
+				languageId = urlPath.substring(start, end);
+			}
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);
 

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageResourcesExtender.java
@@ -151,13 +151,12 @@ public class LanguageResourcesExtender
 
 			String urlPath = url.getPath();
 
-			String languageId = "";
+			String languageId = StringPool.BLANK;
 
-			int start = path.length() + name.length() + 2;
-			int end = urlPath.length() - ".properties".length();
-
-			if (start < end) {
-				languageId = urlPath.substring(start, end);
+			if (urlPath.contains(StringPool.UNDERLINE)) {
+				languageId = urlPath.substring(
+					path.length() + name.length() + 2,
+					urlPath.length() - ".properties".length());
 			}
 
 			Locale locale = LocaleUtil.fromLanguageId(languageId, false);

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageResourcesTest.java
@@ -72,6 +72,41 @@ public class LanguageResourcesTest {
 	}
 
 	@Test
+	public void testLanguageResource() {
+		String key = "year";
+
+		String defaultValue = _language.get(new Locale("", ""), key);
+		String frenchValue = _language.get(LocaleUtil.FRANCE, key);
+
+		Locale defaultLocale = LocaleUtil.FRANCE;
+
+		LocaleUtil.setDefault(
+			defaultLocale.getLanguage(), defaultLocale.getCountry(),
+			defaultLocale.getVariant());
+
+		Assert.assertEquals(
+			frenchValue, _language.get(LocaleUtil.getDefault(), key, null));
+
+		Locale locale = new Locale("ps", "AF");
+
+		_serviceRegistration1 = _bundleContext.registerService(
+			ResourceBundle.class, new TestResourceBundle(_VALUE_1),
+			HashMapDictionaryBuilder.<String, Object>put(
+				Constants.SERVICE_RANKING, 0
+			).put(
+				"language.id", _language.getLanguageId(locale)
+			).build());
+
+		Assert.assertEquals(
+			_VALUE_1,
+			_language.get(locale, TestResourceBundle.class.getName(), null));
+		Assert.assertEquals(defaultValue, _language.get(locale, key, null));
+
+		LocaleUtil.setDefault(
+			_locale.getLanguage(), _locale.getCountry(), _locale.getVariant());
+	}
+
+	@Test
 	public void testLanguageResourceServiceTrackerCustomizer() {
 		_assertValue(null);
 


### PR DESCRIPTION
Previous PR: https://github.com/ericyanLr/liferay-portal/pull/308

Hi @ericyanLr!

I've made adjustments per your suggestions. 

A couple of changes:
1. Used a different key than "Liferay" since I realized that "Liferay" is something we don't actually localize so it'd be the same in basically all languages. 😅 I arbitrarily chose the word "Year" instead. 
2. Added some logic to change the default locale. This is since we want to make sure we're grabbing from language.properties instead of the default locale (which is the current behavior). If we keep the default locale as EN-US (which I'm assuming is the default on the test instances), we won't actually see any difference between default locale and language.properties. So we check the following:
- Pre-determined key against the default locale/language (in this case, fr).
- Key that should exist in unsupported locale to make sure we are grabbing from our registered bundle correctly.
- Key that shouldn't exist in unsupported locale to make sure we are using the blank bundle (or Language.properties) vs the default Locale.

Hopefully this works better now, but let me know if you see any other areas for improvement and I'll try to take a look. Thanks!