### PR TITLE
LPD-38086

### DIFF
--- a/modules/apps/portal-cache/portal-cache-test-util/src/main/java/com/liferay/portal/cache/test/util/TestPortalCache.java
+++ b/modules/apps/portal-cache/portal-cache-test-util/src/main/java/com/liferay/portal/cache/test/util/TestPortalCache.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.cache.test.util;
 
 import com.liferay.portal.cache.BasePortalCache;
-import com.liferay.portal.kernel.cache.PortalCacheManager;
 
 import java.io.Serializable;
 
@@ -21,22 +20,10 @@ import java.util.concurrent.ConcurrentMap;
 public class TestPortalCache<K extends Serializable, V>
 	extends BasePortalCache<K, V> {
 
-	public TestPortalCache(
-		PortalCacheManager<K, V> portalCacheManager, String portalCacheName) {
-
-		super(portalCacheManager);
-
-		_portalCacheName = portalCacheName;
-
-		_concurrentMap = new ConcurrentHashMap<>();
-	}
-
 	public TestPortalCache(String portalCacheName) {
 		super(null);
 
 		_portalCacheName = portalCacheName;
-
-		_concurrentMap = new ConcurrentHashMap<>();
 	}
 
 	@Override
@@ -135,7 +122,8 @@ public class TestPortalCache<K extends Serializable, V>
 		return replaced;
 	}
 
-	private final ConcurrentMap<K, V> _concurrentMap;
+	private final ConcurrentMap<K, V> _concurrentMap =
+		new ConcurrentHashMap<>();
 	private final String _portalCacheName;
 
 }

--- a/modules/apps/portal-cache/portal-cache-test-util/src/main/java/com/liferay/portal/cache/test/util/TestPortalCache.java
+++ b/modules/apps/portal-cache/portal-cache-test-util/src/main/java/com/liferay/portal/cache/test/util/TestPortalCache.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.cache.test.util;
 
 import com.liferay.portal.cache.BasePortalCache;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import java.io.Serializable;
 
@@ -21,16 +22,23 @@ public class TestPortalCache<K extends Serializable, V>
 	extends BasePortalCache<K, V> {
 
 	public TestPortalCache(String portalCacheName) {
+		this(portalCacheName, false);
+	}
+
+	public TestPortalCache(String portalCacheName, boolean sharded) {
 		super(null);
 
 		_portalCacheName = portalCacheName;
+		_sharded = sharded;
 	}
 
 	@Override
 	public List<K> getKeys() {
 		List<K> keys = new ArrayList<>();
 
-		for (K key : _concurrentMap.keySet()) {
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		for (K key : concurrentMap.keySet()) {
 			keys.add(key);
 		}
 
@@ -43,20 +51,29 @@ public class TestPortalCache<K extends Serializable, V>
 	}
 
 	@Override
+	public boolean isSharded() {
+		return _sharded;
+	}
+
+	@Override
 	public void removeAll() {
-		_concurrentMap.clear();
+		_concurrentMaps.clear();
 
 		aggregatedPortalCacheListener.notifyRemoveAll(this);
 	}
 
 	@Override
 	protected V doGet(K key) {
-		return _concurrentMap.get(key);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		return concurrentMap.get(key);
 	}
 
 	@Override
 	protected void doPut(K key, V value, int timeToLive) {
-		V oldValue = _concurrentMap.put(key, value);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		V oldValue = concurrentMap.put(key, value);
 
 		if (oldValue != null) {
 			aggregatedPortalCacheListener.notifyEntryUpdated(
@@ -70,7 +87,9 @@ public class TestPortalCache<K extends Serializable, V>
 
 	@Override
 	protected V doPutIfAbsent(K key, V value, int timeToLive) {
-		V oldValue = _concurrentMap.putIfAbsent(key, value);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		V oldValue = concurrentMap.putIfAbsent(key, value);
 
 		if (oldValue == null) {
 			aggregatedPortalCacheListener.notifyEntryPut(
@@ -82,7 +101,9 @@ public class TestPortalCache<K extends Serializable, V>
 
 	@Override
 	protected void doRemove(K key) {
-		V value = _concurrentMap.remove(key);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		V value = concurrentMap.remove(key);
 
 		aggregatedPortalCacheListener.notifyEntryRemoved(
 			this, key, value, DEFAULT_TIME_TO_LIVE);
@@ -90,7 +111,9 @@ public class TestPortalCache<K extends Serializable, V>
 
 	@Override
 	protected boolean doRemove(K key, V value) {
-		boolean removed = _concurrentMap.remove(key, value);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		boolean removed = concurrentMap.remove(key, value);
 
 		aggregatedPortalCacheListener.notifyEntryRemoved(
 			this, key, value, DEFAULT_TIME_TO_LIVE);
@@ -100,7 +123,9 @@ public class TestPortalCache<K extends Serializable, V>
 
 	@Override
 	protected V doReplace(K key, V value, int timeToLive) {
-		V oldValue = _concurrentMap.replace(key, value);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		V oldValue = concurrentMap.replace(key, value);
 
 		if (oldValue != null) {
 			aggregatedPortalCacheListener.notifyEntryUpdated(
@@ -112,7 +137,9 @@ public class TestPortalCache<K extends Serializable, V>
 
 	@Override
 	protected boolean doReplace(K key, V oldValue, V newValue, int timeToLive) {
-		boolean replaced = _concurrentMap.replace(key, oldValue, newValue);
+		ConcurrentMap<K, V> concurrentMap = _getConcurrentMap();
+
+		boolean replaced = concurrentMap.replace(key, oldValue, newValue);
 
 		if (replaced) {
 			aggregatedPortalCacheListener.notifyEntryUpdated(
@@ -122,8 +149,20 @@ public class TestPortalCache<K extends Serializable, V>
 		return replaced;
 	}
 
-	private final ConcurrentMap<K, V> _concurrentMap =
+	private ConcurrentMap<K, V> _getConcurrentMap() {
+		long companyId = -1L;
+
+		if (_sharded) {
+			companyId = CompanyThreadLocal.getNonsystemCompanyId();
+		}
+
+		return _concurrentMaps.computeIfAbsent(
+			companyId, key -> new ConcurrentHashMap<>());
+	}
+
+	private final ConcurrentMap<Long, ConcurrentMap<K, V>> _concurrentMaps =
 		new ConcurrentHashMap<>();
 	private final String _portalCacheName;
+	private final boolean _sharded;
 
 }

--- a/modules/apps/portal-cache/portal-cache-test-util/src/test/java/com/liferay/portal/cache/test/util/TransactionalPortalCacheTest.java
+++ b/modules/apps/portal-cache/portal-cache-test-util/src/test/java/com/liferay/portal/cache/test/util/TransactionalPortalCacheTest.java
@@ -97,11 +97,18 @@ public class TransactionalPortalCacheTest {
 		);
 
 		_companyThreadLocalMockedStatic.when(
+			CompanyThreadLocal::isLocked
+		).thenCallRealMethod();
+
+		_companyThreadLocalMockedStatic.when(
 			() -> CompanyThreadLocal.setCompanyId(Mockito.anyLong())
 		).thenCallRealMethod();
 
 		_companyIdThreadLocal = ReflectionTestUtil.getFieldValue(
 			CompanyThreadLocal.class, "_companyId");
+
+		_lockedThreadLocal = ReflectionTestUtil.getFieldValue(
+			CompanyThreadLocal.class, "_locked");
 
 		_portalCache = new TestPortalCache<>("Test Portal Cache");
 
@@ -367,6 +374,33 @@ public class TransactionalPortalCacheTest {
 		TransactionalPortalCacheUtil.removeAll(transactionalPortalCache, false);
 
 		TransactionalPortalCacheUtil.commit(false);
+
+		try {
+			TransactionalPortalCacheUtil.begin();
+
+			TransactionalPortalCache<String, String>
+				shardedTransactionalPortalCache =
+					new TransactionalPortalCache<>(
+						new TestPortalCache<>(
+							"Test Sharded Portal Cache", true),
+						false);
+
+			shardedTransactionalPortalCache.put(_KEY_1, _VALUE_1);
+
+			_companyIdThreadLocal.set(_COMPANY_ID_1);
+			_lockedThreadLocal.set(true);
+
+			TransactionalPortalCacheUtil.commit(false);
+		}
+		catch (UnsupportedOperationException unsupportedOperationException) {
+			Assert.assertEquals(
+				"CompanyThreadLocal modification is not allowed",
+				unsupportedOperationException.getMessage());
+		}
+		finally {
+			_companyIdThreadLocal.set(0L);
+			_lockedThreadLocal.set(false);
+		}
 
 		TransactionLifecycleListener transactionLifecycleListener =
 			TransactionalPortalCacheUtil.TRANSACTION_LIFECYCLE_LISTENER;
@@ -1515,6 +1549,7 @@ public class TransactionalPortalCacheTest {
 	private static final String _VALUE_SYSTEM = "VALUE_SYSTEM";
 
 	private static ThreadLocal<Long> _companyIdThreadLocal;
+	private static ThreadLocal<Boolean> _lockedThreadLocal;
 
 	private final MockedStatic<CompanyThreadLocal>
 		_companyThreadLocalMockedStatic = Mockito.mockStatic(

--- a/modules/apps/portal-cache/portal-cache-test-util/src/test/java/com/liferay/portal/cache/test/util/TransactionalPortalCacheTest.java
+++ b/modules/apps/portal-cache/portal-cache-test-util/src/test/java/com/liferay/portal/cache/test/util/TransactionalPortalCacheTest.java
@@ -12,7 +12,9 @@ import com.liferay.portal.cache.TransactionalPortalCache;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.transactional.TransactionalPortalCacheUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.MVCCModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -30,11 +32,16 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Shuyang Zhou
@@ -71,6 +78,31 @@ public class TransactionalPortalCacheTest {
 
 	@Before
 	public void setUp() {
+		_companyThreadLocalMockedStatic.when(
+			CompanyThreadLocal::getCompanyId
+		).thenCallRealMethod();
+
+		_companyThreadLocalMockedStatic.when(
+			CompanyThreadLocal::getNonsystemCompanyId
+		).thenAnswer(
+			(Answer<Long>)invocationOnMock -> {
+				long currentCompanyId = _companyIdThreadLocal.get();
+
+				if (_companyIdThreadLocal.get() == CompanyConstants.SYSTEM) {
+					currentCompanyId = _COMPANY_ID_1;
+				}
+
+				return currentCompanyId;
+			}
+		);
+
+		_companyThreadLocalMockedStatic.when(
+			() -> CompanyThreadLocal.setCompanyId(Mockito.anyLong())
+		).thenCallRealMethod();
+
+		_companyIdThreadLocal = ReflectionTestUtil.getFieldValue(
+			CompanyThreadLocal.class, "_companyId");
+
 		_portalCache = new TestPortalCache<>("Test Portal Cache");
 
 		_testCacheListener = new TestPortalCacheListener<>();
@@ -78,6 +110,11 @@ public class TransactionalPortalCacheTest {
 
 		_portalCache.registerPortalCacheListener(_testCacheListener);
 		_portalCache.registerPortalCacheListener(_testCacheReplicator);
+	}
+
+	@After
+	public void tearDown() {
+		_companyThreadLocalMockedStatic.close();
 	}
 
 	@Test
@@ -376,6 +413,26 @@ public class TransactionalPortalCacheTest {
 
 		_testNoneTransactionalPortalCache(
 			new TransactionalPortalCache<>(_portalCache, false));
+	}
+
+	@Test
+	public void testShardedTransactionalCache() {
+		_portalCache = new TestPortalCache<>("Test Sharded Portal Cache", true);
+
+		_portalCache.registerPortalCacheListener(_testCacheListener);
+		_portalCache.registerPortalCacheListener(_testCacheReplicator);
+
+		testTransactionalCache();
+	}
+
+	@Test
+	public void testShardedTransactionalCacheWithoutTransaction() {
+		_testShardedTransactionalCache(false);
+	}
+
+	@Test
+	public void testShardedTransactionalCacheWithTransaction() {
+		_testShardedTransactionalCache(true);
 	}
 
 	@Test
@@ -851,6 +908,92 @@ public class TransactionalPortalCacheTest {
 
 		_testCacheListener.reset();
 		_testCacheReplicator.reset();
+	}
+
+	private void _testShardedTransactionalCache(boolean transaction) {
+		PortalCache<String, String> portalCache = new TestPortalCache<>(
+			"Test Sharded Portal Cache", true);
+
+		_companyIdThreadLocal.set(CompanyConstants.SYSTEM);
+
+		portalCache.put(_KEY_SYSTEM, _VALUE_SYSTEM);
+
+		_companyIdThreadLocal.set(_COMPANY_ID_1);
+
+		portalCache.put(_KEY_1, _VALUE_1);
+
+		_companyIdThreadLocal.set(_COMPANY_ID_2);
+
+		portalCache.put(_KEY_2, _VALUE_2);
+
+		TestPortalCacheListener<String, String> testPortalCacheListener =
+			new TestPortalCacheListener<>();
+		TestPortalCacheReplicator<String, String> testPortalCacheReplicator =
+			new TestPortalCacheReplicator<>();
+
+		portalCache.registerPortalCacheListener(testPortalCacheListener);
+		portalCache.registerPortalCacheListener(testPortalCacheReplicator);
+
+		_setEnableTransactionalCache(true);
+
+		TransactionalPortalCache<String, String> transactionalPortalCache =
+			new TransactionalPortalCache<>(portalCache, false);
+
+		if (transaction) {
+			TransactionalPortalCacheUtil.begin();
+		}
+
+		_companyIdThreadLocal.set(_COMPANY_ID_1);
+
+		Assert.assertNull(transactionalPortalCache.get(_KEY_2));
+
+		transactionalPortalCache.put(_KEY_2, _VALUE_1);
+
+		Assert.assertEquals(_VALUE_1, transactionalPortalCache.get(_KEY_2));
+
+		if (transaction) {
+			Assert.assertNull(portalCache.get(_KEY_2));
+		}
+		else {
+			Assert.assertEquals(_VALUE_1, portalCache.get(_KEY_2));
+		}
+
+		_companyIdThreadLocal.set(_COMPANY_ID_2);
+
+		Assert.assertEquals(_VALUE_2, portalCache.get(_KEY_2));
+		Assert.assertEquals(_VALUE_2, transactionalPortalCache.get(_KEY_2));
+		Assert.assertNull(transactionalPortalCache.get(_KEY_1));
+
+		if (transaction) {
+			TransactionalPortalCacheUtil.commit(false);
+		}
+
+		testPortalCacheListener.assertActionsCount(1);
+		testPortalCacheListener.assertPut(_KEY_2, _VALUE_1);
+		testPortalCacheReplicator.assertActionsCount(1);
+		testPortalCacheReplicator.assertPut(_KEY_2, _VALUE_1);
+
+		_companyIdThreadLocal.set(_COMPANY_ID_1);
+
+		Assert.assertEquals(_VALUE_1, portalCache.get(_KEY_1));
+		Assert.assertEquals(_VALUE_1, portalCache.get(_KEY_2));
+		Assert.assertEquals(_VALUE_1, transactionalPortalCache.get(_KEY_1));
+		Assert.assertEquals(_VALUE_1, transactionalPortalCache.get(_KEY_2));
+		Assert.assertEquals(_VALUE_SYSTEM, portalCache.get(_KEY_SYSTEM));
+		Assert.assertEquals(
+			_VALUE_SYSTEM, transactionalPortalCache.get(_KEY_SYSTEM));
+
+		_companyIdThreadLocal.set(_COMPANY_ID_2);
+
+		Assert.assertEquals(_VALUE_2, portalCache.get(_KEY_2));
+		Assert.assertEquals(_VALUE_2, transactionalPortalCache.get(_KEY_2));
+		Assert.assertNull(portalCache.get(_KEY_1));
+		Assert.assertNull(portalCache.get(_KEY_SYSTEM));
+		Assert.assertNull(transactionalPortalCache.get(_KEY_1));
+		Assert.assertNull(transactionalPortalCache.get(_KEY_SYSTEM));
+
+		testPortalCacheListener.reset();
+		testPortalCacheReplicator.reset();
 	}
 
 	private void _testTransactionalPortalCache(
@@ -1355,14 +1498,27 @@ public class TransactionalPortalCacheTest {
 		Assert.assertEquals(0, _getTransactionStackSize());
 	}
 
+	private static final long _COMPANY_ID_1 = 1000L;
+
+	private static final long _COMPANY_ID_2 = 2000L;
+
 	private static final String _KEY_1 = "KEY_1";
 
 	private static final String _KEY_2 = "KEY_2";
+
+	private static final String _KEY_SYSTEM = "KEY_SYSTEM";
 
 	private static final String _VALUE_1 = "VALUE_1";
 
 	private static final String _VALUE_2 = "VALUE_2";
 
+	private static final String _VALUE_SYSTEM = "VALUE_SYSTEM";
+
+	private static ThreadLocal<Long> _companyIdThreadLocal;
+
+	private final MockedStatic<CompanyThreadLocal>
+		_companyThreadLocalMockedStatic = Mockito.mockStatic(
+			CompanyThreadLocal.class);
 	private PortalCache<String, String> _portalCache;
 	private TestPortalCacheListener<String, String> _testCacheListener;
 	private TestPortalCacheReplicator<String, String> _testCacheReplicator;

--- a/portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.SkipReplicationThreadLocal;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionAttribute;
 import com.liferay.portal.kernel.transaction.TransactionDefinition;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Shuyang Zhou
@@ -133,11 +135,46 @@ public class TransactionalPortalCacheUtil {
 	public static void commit(boolean readOnly) {
 		PortalCacheMap portalCacheMap = _popPortalCacheMap();
 
-		for (UncommittedBuffer uncommittedBuffer : portalCacheMap.values()) {
-			uncommittedBuffer.commit(readOnly);
-		}
+		Set<Map.Entry<PortalCache<?, ?>, Map<Long, UncommittedBuffer>>>
+			entrySet = portalCacheMap.entrySet();
 
-		portalCacheMap.clear();
+		Iterator<Map.Entry<PortalCache<?, ?>, Map<Long, UncommittedBuffer>>>
+			iterator = entrySet.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<PortalCache<?, ?>, Map<Long, UncommittedBuffer>>
+				portalCacheMapEntry = iterator.next();
+
+			PortalCache<?, ?> portalCache = portalCacheMapEntry.getKey();
+
+			Map<Long, UncommittedBuffer> uncommittedBufferMap =
+				portalCacheMapEntry.getValue();
+
+			for (Map.Entry<Long, UncommittedBuffer> uncommittedBufferEntry :
+					uncommittedBufferMap.entrySet()) {
+
+				UncommittedBuffer uncommittedBuffer =
+					uncommittedBufferEntry.getValue();
+
+				long companyId = CompanyThreadLocal.getCompanyId();
+
+				try {
+					if (portalCache.isSharded()) {
+						CompanyThreadLocal.setCompanyId(
+							uncommittedBufferEntry.getKey());
+					}
+
+					uncommittedBuffer.commit(readOnly);
+				}
+				finally {
+					if (portalCache.isSharded()) {
+						CompanyThreadLocal.setCompanyId(companyId);
+					}
+				}
+			}
+
+			iterator.remove();
+		}
 	}
 
 	public static <K extends Serializable, V> V get(
@@ -145,7 +182,15 @@ public class TransactionalPortalCacheUtil {
 
 		PortalCacheMap portalCacheMap = _peekPortalCacheMap();
 
-		UncommittedBuffer uncommittedBuffer = portalCacheMap.get(portalCache);
+		Map<Long, UncommittedBuffer> uncommittedBufferMap = portalCacheMap.get(
+			portalCache);
+
+		if (uncommittedBufferMap == null) {
+			return null;
+		}
+
+		UncommittedBuffer uncommittedBuffer = uncommittedBufferMap.get(
+			_getPortalCacheCompanyId(portalCache));
 
 		if (uncommittedBuffer == null) {
 			return null;
@@ -180,7 +225,14 @@ public class TransactionalPortalCacheUtil {
 
 		PortalCacheMap portalCacheMap = _peekPortalCacheMap();
 
-		UncommittedBuffer uncommittedBuffer = portalCacheMap.get(portalCache);
+		Map<Long, UncommittedBuffer> uncommittedBufferMap =
+			portalCacheMap.computeIfAbsent(
+				portalCache, key2 -> new HashMap<>());
+
+		long companyId = _getPortalCacheCompanyId(portalCache);
+
+		UncommittedBuffer uncommittedBuffer = uncommittedBufferMap.get(
+			companyId);
 
 		if (uncommittedBuffer == null) {
 			if (mvcc) {
@@ -192,7 +244,7 @@ public class TransactionalPortalCacheUtil {
 					(PortalCache<Serializable, Object>)portalCache);
 			}
 
-			portalCacheMap.put(portalCache, uncommittedBuffer);
+			uncommittedBufferMap.put(companyId, uncommittedBuffer);
 		}
 
 		uncommittedBuffer.put(
@@ -205,7 +257,13 @@ public class TransactionalPortalCacheUtil {
 
 		PortalCacheMap portalCacheMap = _peekPortalCacheMap();
 
-		UncommittedBuffer uncommittedBuffer = portalCacheMap.get(portalCache);
+		Map<Long, UncommittedBuffer> uncommittedBufferMap =
+			portalCacheMap.computeIfAbsent(portalCache, key -> new HashMap<>());
+
+		long companyId = _getPortalCacheCompanyId(portalCache);
+
+		UncommittedBuffer uncommittedBuffer = uncommittedBufferMap.get(
+			companyId);
 
 		if (uncommittedBuffer == null) {
 			if (mvcc) {
@@ -217,7 +275,7 @@ public class TransactionalPortalCacheUtil {
 					(PortalCache<Serializable, Object>)portalCache);
 			}
 
-			portalCacheMap.put(portalCache, uncommittedBuffer);
+			uncommittedBufferMap.put(companyId, uncommittedBuffer);
 		}
 
 		uncommittedBuffer.removeAll(SkipReplicationThreadLocal.isEnabled());
@@ -231,7 +289,20 @@ public class TransactionalPortalCacheUtil {
 
 	protected static class PortalCacheMap
 		extends HashMap
-			<PortalCache<? extends Serializable, ?>, UncommittedBuffer> {
+			<PortalCache<? extends Serializable, ?>,
+			 Map<Long, UncommittedBuffer>> {
+	}
+
+	private static Long _getPortalCacheCompanyId(
+		PortalCache<?, ?> portalCache) {
+
+		long companyId = -1L;
+
+		if (portalCache.isSharded()) {
+			companyId = CompanyThreadLocal.getNonsystemCompanyId();
+		}
+
+		return companyId;
 	}
 
 	private static boolean _isTransactionalCacheEnabled() {


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-38086

**Question 1**
For `TransactionalPortalCacheUtil.commit`, do we need any additional handling for the possibility of an exception being thrown, such as during the call to: `CompanyThreadLocal.setCompanyId`

Current approach is to clear each of the `portalCacheMap` entries as we iterate, but not sure whether we always want to clear all entries, regardless of whether there is an error.

**Question 2**
For `TransactionalPortalCacheUtil.removeAll`, it looks like the current behavior only removes the entries for a single company. For example, if we have a `ShardedEhcachePortalCache`, calling `removeAll` only clears the entries for whichever `companyId` is set in: `CompanyThreadLocal.getNonsystemCompanyId()`

And so, the current changes in this PR reflect this current behavior. 

Just wanted to bring this up, in case this is not the expected behavior.